### PR TITLE
Scenario checking and ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -282,49 +282,47 @@ export class CreateIntegrationPanel {
     return newScenarioValue;
   }
 
-  private _getNewScenariosString(): string {
-    // extract scenario names and sort
-    let newScenarios : string[] = this._scenarioFieldValues.map( el => this._getNewScenarioValue(el)).sort();
-
-    let newScenariosString: string = '';
-    for (let index = 0; index < newScenarios.length; index++) {
-      if (newScenarios[index] !== '') {
-        // remove parent folder indicator if present
-        newScenariosString += '\n    ' + '"' + newScenarios[index] + '"';
-
-        // check if comma is needed
-        let remainingScenarios: string[] = newScenarios.slice(index + 1, newScenarios.length);
-        if (!isEmptyStringArray(remainingScenarios)) {
-          newScenariosString += ',';
-        }
-      }
-    }
-    return newScenariosString;
-  }
-
   private _getScenariosString(): string {
     let scenariosString = '';     // pre-allocate
 
-    // add existing scenarios
+    // pre-allocate scenario object array
+    let scenarioObjectArray : {execute: boolean, name: string}[] = [];
+
+    // add existing scenarios (if 'update')
     if (this._createUpdateValue === 'update') {
       for (let index = 0; index < this._existingScenarioFieldValues.length; index++) {
-        let commenting = '# ';
-        if (this._existingScenarioCheckboxValues[index]) {
-          commenting = '';
-        }
-
-        scenariosString += '\n    ' + commenting + '"' + this._existingScenarioFieldValues[index] + '"';
-
-        // check if comma is needed
-        let remainingCheckboxes: boolean[] = this._existingScenarioCheckboxValues.slice(index + 1, this._existingScenarioCheckboxValues.length);
-        if ((remainingCheckboxes.filter(el => el === true).length > 0) || !isEmptyStringArray(this._scenarioFieldValues)) {
-          scenariosString += ',';
-        }
+        scenarioObjectArray.push( {
+          execute: this._existingScenarioCheckboxValues[index],
+          name: this._existingScenarioFieldValues[index]
+        });
       }
     }
 
-    // add 'new' scenarios
-    scenariosString += this._getNewScenariosString();
+    // add new scenarios
+    let newScenarios : string[] = this._scenarioFieldValues.map( el => this._getNewScenarioValue(el)).sort();
+    for (const scenario of newScenarios) {
+      if (!isEmpty(scenario)) {
+        scenarioObjectArray.push( {
+          execute: true,
+          name: scenario
+        });
+      }
+    }
+
+    // sort
+    scenarioObjectArray.sort((a, b) => (a.name > b.name) ? 1 : -1);
+
+    // build scenario string
+    for (let index = 0; index < scenarioObjectArray.length; index++) {
+      let scenarioObject = scenarioObjectArray[index];
+      scenariosString += '\n    ' + (scenarioObject.execute ? '' : '#') + '"' + scenarioObject.name + '"'; 
+
+      // check if comma is needed
+      let remaining : boolean[] = scenarioObjectArray.slice(index+1, scenarioObjectArray.length).map( x => x.execute);
+      if (remaining.includes(true)) {
+        scenariosString += ',';
+      }
+    }
 
     // add 'Scenarios'  label
     scenariosString = '$Scenarios = @(' + scenariosString + '\n )';

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getUri, getWorkspaceFile, getWorkspaceFiles, getExtensionFile, startScript, cleanPath, parentPath, nth, dropdownOptions, arrayFrom1, toBoolean, isEmptyStringArray, arrayFrom0 } from "../utilities/functions";
+import { getUri, getWorkspaceFile, getWorkspaceFiles, startScript, cleanPath, parentPath, toBoolean, isEmptyStringArray, isEmpty} from "../utilities/functions";
 import * as fs from 'fs';
 import { CreateIntegrationHtmlObject } from "./CreateIntegrationHtmlObject";
 
@@ -275,21 +275,26 @@ export class CreateIntegrationPanel {
   }
 
   private _getNewScenarioValue(fieldValue:string) : string {
-    return fieldValue.replace(/[^\>]+\> /g, '');
+    let newScenarioValue = '';
+    if (!isEmpty(fieldValue)) {
+      newScenarioValue = fieldValue.replace(/[^\>]+\> /g, '');
+    }
+    return newScenarioValue;
   }
 
   private _getNewScenariosString(): string {
+    // extract scenario names and sort
+    let newScenarios : string[] = this._scenarioFieldValues.map( el => this._getNewScenarioValue(el)).sort();
 
     let newScenariosString: string = '';
-    for (let index = 0; index < this._scenarioFieldValues.length; index++) {
-      if (this._scenarioFieldValues[index] !== undefined && this._scenarioFieldValues[index] !== '') {
+    for (let index = 0; index < newScenarios.length; index++) {
+      if (newScenarios[index] !== '') {
         // remove parent folder indicator if present
-        let scenarioName = this._getNewScenarioValue(this._scenarioFieldValues[index]);
-        newScenariosString += '\n    ' + '"' + scenarioName + '"';
+        newScenariosString += '\n    ' + '"' + newScenarios[index] + '"';
 
         // check if comma is needed
-        let remainingFieldValues: string[] = this._scenarioFieldValues.slice(index + 1, this._scenarioFieldValues.length);
-        if (!isEmptyStringArray(remainingFieldValues)) {
+        let remainingScenarios: string[] = newScenarios.slice(index + 1, newScenarios.length);
+        if (!isEmptyStringArray(remainingScenarios)) {
           newScenariosString += ',';
         }
       }

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -274,13 +274,17 @@ export class CreateIntegrationPanel {
     terminal.sendText(`./${this._getScriptName()}`);
   }
 
+  private _getNewScenarioValue(fieldValue:string) : string {
+    return fieldValue.replace(/[^\>]+\> /g, '');
+  }
+
   private _getNewScenariosString(): string {
 
     let newScenariosString: string = '';
     for (let index = 0; index < this._scenarioFieldValues.length; index++) {
       if (this._scenarioFieldValues[index] !== undefined && this._scenarioFieldValues[index] !== '') {
         // remove parent folder indicator if present
-        let scenarioName = this._scenarioFieldValues[index].replace(/[^\>]+\> /g, '');
+        let scenarioName = this._getNewScenarioValue(this._scenarioFieldValues[index]);
         newScenariosString += '\n    ' + '"' + scenarioName + '"';
 
         // check if comma is needed

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -446,7 +446,7 @@ export class CreateIntegrationPanel {
       return ((element !== null) && ("" + element !== ""));
     });
 
-    return scenarios;
+    return scenarios.sort();
   }
 
   private _cropFlexFields() {

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -107,6 +107,10 @@ export function toBoolean(string:string) : boolean {
 	return outString;
 }
 
+export function isEmpty(string: string) : boolean {
+	return (string === undefined || string === null || string === '');
+}
+
 export function isEmptyStringArray(array: string[]) : boolean {
 	let isEmpty: boolean = true;
 


### PR DESCRIPTION
Added:
- now disallows execution of create/update if form contains duplicate scenarios
- reads/writes scenarios from/to integration script file in alphabetical order, both when 'create' and 'update'
  - This means the 'existing scenarios' also show in alphabetical order in the 'update' form