### PR TITLE
Scenario type mixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.3.1
+- Carrier Integration
+  - When updating existing integrations, switching 'modular' checkbox is no longer restricted
+    - Mixing new modular with existing non-modular scenarios is now allowed
+    - When loading existing integration, modular checkbox is no longer updated
+    - When loading existing integration, scenario fields are no longer cleared
+  - Refactor: Script no longer needs 'Modular' flag input -> Modularity is determined on scenario level
+  - Updated along with PowerShell script
+
 ## 1.3.0
 - Carrier Integration & Postman Collection
   - Modular scenario creation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -21,13 +21,15 @@ export function addScenarioEventListeners(vscodeApi) {
 
 export var clickTile = function (vscodeApi) { return function (event) {
     const field = event.target;
+    const base = 'm';
   
     // add/remove tile content to last selected text field
     let currentElements = currentInput.value.split('-');
     if (currentElements.includes(field.id)) {
-      currentInput.value = currentElements.filter(el => el !== field.id).join('-');
+      let newValue = currentElements.filter(el => el !== field.id).join('-');
+      currentInput.value = (newValue === base) ? '' : newValue;
     } else {
-      currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? '' : '-') + field.id;
+      currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? (base + '-') : '-') + field.id;
     }
   
     // save field value

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -278,6 +278,13 @@ export class CreateIntegrationPanel {
       // replace CreateOrUpdate value
       newScriptContent = newScriptContent.replace(/\$CreateOrUpdate = '[^']+'/g, '$CreateOrUpdate = \'update\'');
 
+      // replace New-UpdateIntegration function call
+      let newNewUpdateIntegration = 'New-UpdateIntegration -CarrierName $CarrierName -Module $Module -CarrierAPI $CarrierAPI -Scenarios $Scenarios -StringReplaceList $StringReplaceList -CreateOrUpdate $CreateOrUpdate -Steps $Steps -Test';
+      newScriptContent = newScriptContent.replace(/New-UpdateIntegration\s[\S\s]+$/g,newNewUpdateIntegration);
+
+      // remove modular value if present
+      newScriptContent = newScriptContent.replace(/\$ModularXMLs[^\r\n]+[\r\n]/g, '');
+
       // save to file
       let newScriptPath:string = parentPath(cleanPath(this._currentIntegration.path)) + '/' + this._getScriptName();
       fs.writeFileSync(newScriptPath, newScriptContent, 'utf8');
@@ -391,7 +398,7 @@ export class CreateIntegrationPanel {
     newScriptContent = newScriptContent.replace('[createupdate]', this._createUpdateValue + "");
 
     // modular
-    newScriptContent = newScriptContent.replace('[modular]', this._modularValue + "");
+    // newScriptContent = newScriptContent.replace('[modular]', this._modularValue + "");
 
     // scenarios
     newScriptContent = newScriptContent.replace(/\$Scenarios = \@\([^\)]+\)/g, this._getScenariosString());

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -177,11 +177,11 @@ export class CreateIntegrationPanel {
       this._createUpdateValue = 'update';
 
       // update modular value from script
-      if (this._modularValue !== this._currentIntegration.modular) {
-        // if modular checkbox switches: clear scenario fields
-        this._scenarioFieldValues = [];
-      }
-      this._modularValue = this._currentIntegration.modular;
+      // if (this._modularValue !== this._currentIntegration.modular) {
+      //   // if modular checkbox switches: clear scenario fields
+      //   this._scenarioFieldValues = [];
+      // }
+      // this._modularValue = this._currentIntegration.modular;
 
       // update valid existing scenario values from scenario folder instead
       this._existingScenarioFieldValues = this._currentIntegration.validscenarios;

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -339,9 +339,8 @@ export class CreatePostmanCollectionPanel {
     let defScenariosString = (this._independent) ? `$Scenarios = @( ${newScenariosString} )` : '';
 
     let applyScenariosString = (this._independent) ? '-Scenarios $Scenarios' : '';
-    let modularString = this._modularValue ? '-Modular' : '';
     let loadFunctions = `. "..\\..\\scenario-templates\\scripts\\functions.ps1"`;
-    let createPostmanCollection = `New-PostmanCollection -StringReplaceList $StringReplaceList -Headers $Headers ${applyScenariosString} ${modularString} -Test`;
+    let createPostmanCollection = `New-PostmanCollection -StringReplaceList $StringReplaceList -Headers $Headers ${applyScenariosString} -Test`;
     let nl = '\n';
 
     return stringReplaceList + nl + headers + nl + defScenariosString + nl + loadFunctions + nl + createPostmanCollection;

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -86,7 +86,7 @@ export class ScenarioGridObject {
                 // cycle through elements in given parent folder
                 let elements = this._modularElementsWithParents.filter(el => el.parent === parent).map(el => el.element).sort();
                 for (const element of elements) {
-                    if (element !== 'standard') {
+                    if (element !== 'm') {
                         modularTiles += this._getModularTile(element);
                     }
                 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -138,8 +138,9 @@ export async function getAvailableIntegrations(panel:string) : Promise<{path:str
 		let integrationScenarios = scenarioDir.filter(el => !el.includes('.')).sort();
 
 		// filter on valid scenarios
-		let valids : string[] = modular ? await getModularElements(module) : await getAvailableScenarios(module, false);
-		let validScenarios : string [] = integrationScenarios.filter(el => isScenarioValid(el, modular, valids));
+		let availableScenarios = await getAvailableScenarios(module, false);
+		let modularElements = await getModularElements(module);
+		let validScenarios : string [] = integrationScenarios.filter(el => isScenarioValid(el, availableScenarios, modularElements));
 
 		// add array element
 		integrationObjects[newIndex] = {
@@ -159,11 +160,11 @@ export async function getAvailableIntegrations(panel:string) : Promise<{path:str
 	return integrationObjects.slice(0,newIndex);
 }
 
-export function isScenarioValid(scenario:string, modular:boolean, validScenarios: string[]) : boolean {
+export function isScenarioValid(scenario:string, availableScenarios: string[], modularElements: string[]) : boolean {
 	let isValid = true;
+	let modular = scenario.startsWith('m-');
 	if (modular) {
 		let currentElements = scenario.split('-');
-		let modularElements = validScenarios;
 		for (const element of currentElements) {
 			if (!modularElements.includes(element)) {
 				isValid = false;
@@ -171,7 +172,7 @@ export function isScenarioValid(scenario:string, modular:boolean, validScenarios
 			}
 		}
 	} else {
-		isValid = validScenarios.includes(scenario);
+		isValid = availableScenarios.includes(scenario);
 	}
 
 	return isValid;


### PR DESCRIPTION
- Carrier Integration
  - When updating existing integrations, switching 'modular' checkbox is no longer restricted
    - Mixing new modular with existing non-modular scenarios is now allowed
    - When loading existing integration, modular checkbox is no longer updated
    - When loading existing integration, scenario fields are no longer cleared
  - Refactor: Script no longer needs 'Modular' flag input -> Modularity is determined on scenario level
  - Updated along with PowerShell script