### PR TITLE
Multi package advanced support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.4.0 
+- Modular Scenarios (general)
+  - Modular scenario generation is now multi-package compatible
+    - Supports up to 9 packages per scenario
+    - Number of packages settable per scenario
+      - Auto-adds and updates `multi` element with set number of packages to each scenario
+    - Auto-detects which elements contain a `<ShipmentPackage>` node, and auto-adds package indices field upon tile selection
+    - Field value checks on scenario and package indices field levels
+      - checks if package indices between 1 and scenario-set number of packages, and no doubles present (and not empty)
+      - Adds appropriate red field outline and hover-over tooltips
+      - Does not allow integration creation/update or postman collection creation if any invalid fields
+  - Updated tile view
+    - Now lined up vertically to the right of the scenario list, with parent folder name auto-added as tile list header
+    - Any element in root folder is not shown (reserved for auto-added elements like `m` and `multi`)
+
 ## 1.3.1
 - Modular Scenarios (general)
   - Modular scenario fields can now only be updated using the tiles (no more free typing)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/createintegration/main.js
+++ b/scripts/createintegration/main.js
@@ -80,7 +80,7 @@ function fieldChange(event) {
       if (field.id === 'modulename') {
         vscodeApi.postMessage({ command: "clearscenarios", text: '' });
       }
-      vscodeApi.postMessage({ command: "refreshpanel", text: '' });
+      //vscodeApi.postMessage({ command: "refreshpanel", text: '' });
       break;
 
     // stepdropdown: show/hide other step field

--- a/scripts/createintegration/style.css
+++ b/scripts/createintegration/style.css
@@ -17,7 +17,8 @@
 }
 
 .existingscenariofield {
-  width: 20rem;
+  width: 25rem;
+  resize: true;
 }
 
 .stepfield {

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -93,6 +93,6 @@ h1 {
 
 #nofpackages, 
 .multifield {
-  width: 0.5rem;
+  width: 7rem;
 }
   

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -89,4 +89,8 @@ h1 {
 .scenariofield {
   width: 25rem;
 }
+
+#nofpackages {
+  width: 0.5rem;
+}
   

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -91,8 +91,15 @@ h1 {
   width: 25rem;
 }
 
-#nofpackages, 
+#nofpackages{
+  width: 7rem;
+}
+
 .multifield {
   width: 7rem;
 }
-  
+
+.modulartile,
+.multifield {
+  vertical-align:middle;
+}  

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -18,6 +18,7 @@
 .component-example {
   margin-bottom: 0.5rem;
   width: 100%;
+  /* vertical-align: text-top; */
 }
 
 .component-nomargin {
@@ -90,7 +91,8 @@ h1 {
   width: 25rem;
 }
 
-#nofpackages {
+#nofpackages, 
+.multifield {
   width: 0.5rem;
 }
   

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -101,5 +101,5 @@ h1 {
 
 .modulartile,
 .multifield {
-  vertical-align:middle;
+  vertical-align: middle;
 }  

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -184,8 +184,8 @@ export function setPrimary(fieldId,vscodeApi) {
     }
 
     //show multi field
-    //multifield[0].hidden = false;
-    multifield[0].disabled = false;
+    multifield[0].hidden = false;
+    // multifield[0].disabled = false;
   }
 
   // add tile content to last selected scenario field
@@ -218,8 +218,8 @@ export function setSecondary(fieldId,vscodeApi) {
     multifield[0].dispatchEvent(new Event('keyup'));
 
     //hide multi field
-    //multifield[0].hidden = true;
-    multifield[0].disabled = true;
+    multifield[0].hidden = true;
+    // multifield[0].disabled = true;
 
     // update validity check
     updateMultiFieldOutlineAndTooltip(multifield[0].id);
@@ -332,7 +332,8 @@ export function updateMultiFieldOutlineAndTooltip(fieldId) {
   let field = document.getElementById(fieldId);
   let maxValue = document.getElementById("nofpackages").value;
 
-  if (field.value === '' && field.disabled === false) {
+  // if (field.value === '' && field.disabled === false) {
+  if (field.value === '' && field.hidden === false) {
     updateMultiFieldEmpty(field.id);
   } else if (field.value.includes('0')) {
     updateMultiFieldWrong(field.id, 'May not contain 0 (only 1-9, and no higher than number of packages)');

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -27,25 +27,13 @@ export function addScenarioEventListeners(vscodeApi) {
 
 export var clickTile = function (vscodeApi) { return function (event) {
     const field = event.target;
-    const base = 'm';
   
-    // add/remove tile content to last selected text field
-    let currentElements = currentInput.value.split('-');
-    if (currentElements.includes(field.id)) {
-      let newValue = currentElements.filter(el => el !== field.id).join('-');
-      currentInput.value = (newValue === base) ? '' : newValue;
+    // update tile appearance and possibly set multi field
+    if (field.getAttribute('appearance') === 'primary'){
+      setSecondary(field.id,vscodeApi);
     } else {
-      currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? (base + '-') : '-') + field.id;
+      setPrimary(field.id,vscodeApi);
     }
-  
-    // save field value
-    //saveScenarioValue(currentInput.id, vscodeApi);
-  
-    // trigger 'change' event to save and check content
-    currentInput.dispatchEvent(new Event('change'));
-  
-    // update appearance on click
-    flipTile(field.id, vscodeApi);
 };};
 
 export var scenarioFieldChange = function (vscodeApi) { return  function (event) {
@@ -91,16 +79,6 @@ export function saveScenarioValue(fieldId, vscodeApi) {
     vscodeApi.postMessage({ command: "savevalue", text: textString });
 }
 
-export function flipTile(fieldId, vscodeApi) {
-    let field = document.getElementById(fieldId);
-  
-    if (field.getAttribute('appearance') === 'primary'){
-      setSecondary(field.id,vscodeApi);
-    } else {
-      setPrimary(field.id,vscodeApi);
-    }
-}
-
 export function lowestUnusedDigitOr1() {
   let multifields = document.querySelectorAll(".multifield");
   let concatenatedValues = '';
@@ -109,6 +87,7 @@ export function lowestUnusedDigitOr1() {
     concatenatedValues += multifield.value;
   }
 
+  //TODO: max should be nofPackages value OR 1
   for (const digit of [...Array(9).keys()].map(x => ++x)) {
     if (!concatenatedValues.includes(digit+"")) {
       lowestUnused = digit;
@@ -121,36 +100,60 @@ export function lowestUnusedDigitOr1() {
 
 export function setPrimary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
+  const base = 'm';
 
   // change appearance
   field.setAttribute('appearance','primary');
 
+  // set multifield if present
   let multifield = document.querySelectorAll("#multifield" + fieldId);
   // vscodeApi.postMessage({ command: "setprime", text: multifield[0].id });
   if (multifield.length > 0) {
-    //TODO: calculate multi value (lowest unused digit or 1)
+    //calculate multi value (lowest unused digit or 1)
     multifield[0].value = lowestUnusedDigitOr1() + "";
 
     //show multi field
     //multifield[0].hidden = false;
     multifield[0].disabled = false;
   }
+
+  // add tile content to last selected scenario field
+  let currentElements = currentInput.value.split('-');
+  if (!currentElements.includes(field.id)) {
+    currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? (base + '-') : '-') + field.id;
+
+    // trigger 'change' event to save and check content
+    currentInput.dispatchEvent(new Event('change'));
+  }
 }
 
 export function setSecondary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
+  const base = 'm';
 
   // change appearance
   field.setAttribute('appearance','secondary');
 
+  // clear multifield if present
   let multifield = document.querySelectorAll("#multifield" + fieldId);
   if (multifield.length > 0) {
 
-    //TODO: clear multi value
+    //clear multi value
     multifield[0].value = '';
+
     //hide multi field
     //multifield[0].hidden = true;
     multifield[0].disabled = true;
+  }
+
+  // remove tile content from last selected scenario field
+  let currentElements = currentInput.value.split('-');
+  if (currentElements.includes(field.id)) {
+    let newValue = currentElements.filter(el => el !== field.id).join('-');
+    currentInput.value = (newValue === base) ? '' : newValue;
+
+    // trigger 'change' event to save and check content
+    currentInput.dispatchEvent(new Event('change'));
   }
 }
 

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -19,6 +19,11 @@ export function addScenarioEventListeners(vscodeApi) {
   // modular checkbox
   document.getElementById("modular").addEventListener("change", scenarioFieldChange(vscodeApi));
 
+  // nofPackages
+  for (const field of document.querySelectorAll("#nofpackages")) {
+    field.addEventListener("change", changePackages);
+  }
+
   // if modular: check currentInput content and update tiles
   if (isModular()) {
     updateTiles(currentInput.value);
@@ -52,6 +57,18 @@ export var scenarioFieldChange = function (vscodeApi) { return  function (event)
     }
 };};
   
+export function changePackages(event) {
+  const nofPackages = event.target.value;
+
+  // cycle through al scenario fields, and update with new nofPackages
+  for (const field of document.querySelectorAll(".scenariofield")) {
+    field.value = field.value.replace(/-multi_\d-/g,"-multi_" + nofPackages + "-");
+
+    // trigger 'change' event to save and check content
+    field.dispatchEvent(new Event('change'));
+  }
+}
+
 export function modularScenarioFocus(event) {
     // track last selected scenario field
     // from https://stackoverflow.com/a/68176703/1716283
@@ -81,14 +98,15 @@ export function saveScenarioValue(fieldId, vscodeApi) {
 
 export function lowestUnusedDigitOr1() {
   let multifields = document.querySelectorAll(".multifield");
+  let maxValue = +document.getElementById("nofpackages").value;
   let concatenatedValues = '';
   let lowestUnused = 0;
   for (const multifield of multifields) {
     concatenatedValues += multifield.value;
   }
 
-  //TODO: max should be nofPackages value OR 1
-  for (const digit of [...Array(9).keys()].map(x => ++x)) {
+  // get lowest unused digit (max is nofPackages)
+  for (const digit of [...Array(maxValue).keys()].map(x => ++x)) {
     if (!concatenatedValues.includes(digit+"")) {
       lowestUnused = digit;
       break;
@@ -100,7 +118,7 @@ export function lowestUnusedDigitOr1() {
 
 export function setPrimary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
-  const base = 'm';
+  const base = 'm-multi_' + document.getElementById("nofpackages").value ;
 
   // change appearance
   field.setAttribute('appearance','primary');
@@ -132,7 +150,7 @@ export function setPrimary(fieldId,vscodeApi) {
 
 export function setSecondary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
-  const base = 'm';
+  const base = 'm-multi_' + document.getElementById("nofpackages").value ;
 
   // change appearance
   field.setAttribute('appearance','secondary');

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -207,7 +207,7 @@ export function setSecondary(fieldId,vscodeApi) {
   if (check) {
     // replace if multi, else replace if not multi
     let multiregex = new RegExp('-' + field.id + '_\\d+(-|$)');
-    let newValue = currentInput.value.replace(multiregex, '$1').replace(regex, check[1]);
+    let newValue = currentInput.value.replace(multiregex, '$1').replace(regex, check[1] === '-' ? '-' : '');
     currentInput.value = (newValue === base) ? '' : newValue;
 
     // trigger 'change' event to save and check content

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -60,7 +60,7 @@ export var multiFieldChange = function (vscodeApi) { return  function (event) {
 
   // update scenario in currentInput
   let element = field.id.replace('multifield','');
-  let multiregex = new RegExp('-' + element + '_\\d+(-|$)');
+  let multiregex = new RegExp('-' + element + '_\\d*(-|$)');
   currentInput.value = currentInput.value.replace(multiregex, '-' + element + '_' + value + '$1');
 
   // trigger 'change' event to save and check content
@@ -207,18 +207,24 @@ export function setSecondary(fieldId,vscodeApi) {
     //hide multi field
     //multifield[0].hidden = true;
     multifield[0].disabled = true;
+
+    // update validity check
+    updateMultiFieldOutlineAndTooltip(multifield[0].id);
   }
 
   // remove tile content from last selected scenario field
-  let regex = new RegExp('-' + field.id + '([-_]|$)');
-  let check = currentInput.value.match(regex);
-  if (check) {
-    // replace if multi, else replace if not multi
-    let multiregex = new RegExp('-' + field.id + '_\\d+(-|$)');
-    let newValue = currentInput.value.replace(multiregex, '$1').replace(regex, check[1] === '-' ? '-' : '');
-    currentInput.value = (newValue === base) ? '' : newValue;
+  let oldValue = currentInput.value;
+  let nonmultiregex = new RegExp('-' + field.id + '(-|$)');
+  let multiregex = new RegExp('-' + field.id + '_\\d*(-|$)');
 
-    // trigger 'change' event to save and check content
+  // replace if multi, else replace if not multi
+  let newValue = currentInput.value.replace(multiregex, '$1').replace(nonmultiregex, '$1');
+
+  // remove base if all tiles deselected
+  currentInput.value = (newValue === base) ? '' : newValue;
+
+  // if updated: trigger 'change' event to save and check content
+  if (currentInput.value !== oldValue) {
     currentInput.dispatchEvent(new Event('change'));
   }
 }

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -121,6 +121,11 @@ export function modularScenarioFocus(event) {
 
       // update tiles
       updateTiles(currentInput.value);
+
+      // check all multifield values
+      for (const field of document.querySelectorAll(".multifield")) {
+        updateMultiFieldOutlineAndTooltip(field.id);
+      }
     }
 }
 
@@ -163,9 +168,17 @@ export function setPrimary(fieldId,vscodeApi) {
   let multifield = document.querySelectorAll("#multifield" + fieldId);
 
   if (multifield.length > 0) {
-    //calculate multi value (lowest unused digit or 1) unless already set
+    
+    // extract current value from scenario field (if present)
+    let multiregex = new RegExp('-' + field.id + '_(\\d*)(-|$)');
+    let matchMultiInScenario = currentInput.value.match(multiregex);
+    if (matchMultiInScenario) {
+      multifield[0].value = matchMultiInScenario[1];
+    } else 
     if (multifield[0].value === '') {
+      //calculate multi value (lowest unused digit or 1) unless already set
       multifield[0].value = lowestUnusedDigitOr1() + "";
+
       // trigger 'keyup' event to save and check content
       multifield[0].dispatchEvent(new Event('keyup'));
     }

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -273,22 +273,6 @@ export function updateTiles(content) {
     }
 }
 
-export function checkModularScenario(content) {
-    let currentElements = content.split('-');
-    let modularElements = document.getElementById("modularelements").value.split(',');
-    let isValid = true;
-    if (currentElements !== null && !(currentElements.length === 1 && currentElements[0] === '')) {
-      for (let index = 0; index < currentElements.length; index++) {
-        if (!modularElements.includes(currentElements[index])) {
-          isValid = false;
-          break;
-        }
-      }
-    }
-  
-    return isValid;
-}
-
 export function isModular() {
     return document.getElementById("modular").checked;
 }
@@ -322,6 +306,25 @@ export function containsHigherDigits(string, maxdigit) {
   }
 
   return containsHigher;
+}
+
+export function checkModularScenario(content) {
+  let isCorrect = true;
+
+  // check if modular scenario contains invalid multi strings
+  let currentElements = content.split('-');
+  let maxValue = document.getElementById("nofpackages").value;
+
+  for (const element of currentElements) {
+    let multiValue = element.replace(/[^\_]+\_/g,'');
+
+    if (element.includes('_') && (multiValue.includes('0') || containsHigherDigits(multiValue, maxValue) || containsRepeatingDigits(multiValue, maxValue))) {
+      isCorrect = false;
+      break;
+    }
+  }
+
+  return isCorrect;
 }
 
 export function updateMultiFieldOutlineAndTooltip(fieldId) {
@@ -361,16 +364,14 @@ export function updateScenarioFieldOutlineAndTooltip(fieldId) {
     let isCorrect = true;
     let field = document.getElementById(fieldId);
   
-    var fieldType = field.className;
-  
     if (field.classList[0] === 'scenariofield') {
         // check for duplicate scenarios
         if (isScenarioDuplicate(field.id) && !isEmpty(field.value)) {
           isCorrect = false;
           updateScenarioFieldDuplicate(field.id);
-        // } else if (isModular() && !checkModularScenario(field.value)) {
-        //   updateScenarioFieldWrongModularScenario(field.id,fieldType);
-        //   isCorrect = false;
+        } else if (isModular() && !checkModularScenario(field.value)) {
+          updateScenarioFieldWrongModularScenario(field.id);
+          isCorrect = false;
         } else if (field.id === currentInput.id && isModular()) { 
           updateScenarioFieldFocused(field.id);
         } else {
@@ -390,7 +391,7 @@ export function updateScenarioFieldDuplicate(fieldId) {
 export function updateScenarioFieldWrongModularScenario(fieldId) {
     let field = document.getElementById(fieldId);
     field.style.outline = "1px solid red";
-    field.title = 'Format: \'fromnl-tode-sl1800\'. Elements must be present in scenario-elements/modular.';
+    field.title = 'One or more modular element fields are invalid. select scenario to see more details.';
 }
   
 export function updateScenarioFieldRight(fieldId, info="") {

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -21,7 +21,7 @@ export function addScenarioEventListeners(vscodeApi) {
 
   // nofPackages dropdowns
   for (const field of document.querySelectorAll(".nofpackages")) {
-    field.addEventListener("change", changePackagesDropdown(vscodeApi));
+    field.addEventListener("change", changePackages(vscodeApi));
   }
 
   // multi fields
@@ -84,7 +84,7 @@ export var scenarioFieldChange = function (vscodeApi) { return  function (event)
     }
 };};
 
-export var changePackagesDropdown = function (vscodeApi) { return  function (event) {
+export var changePackages = function (vscodeApi) { return  function (event) {
     const nofPackagesField = event.target;
     const nofPackages = nofPackagesField.value;
     const index = nofPackagesField.getAttribute('index');
@@ -99,8 +99,11 @@ export var changePackagesDropdown = function (vscodeApi) { return  function (eve
     // update scenario field with new nofPackages
     scenarioField.value = scenarioField.value.replace(/-multi_\d-/g,"-multi_" + nofPackages + "-");
 
+    // trigger 'change' event to save and check content
+    scenarioField.dispatchEvent(new Event('change')); 
+
     // update scenario field validity check
-    updateScenarioFieldOutlineAndTooltip(scenarioField.id);
+    //updateScenarioFieldOutlineAndTooltip(scenarioField.id);
 
     // check all multifield values
     for (const field of document.querySelectorAll(".multifield")) {

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -94,12 +94,31 @@ export function saveScenarioValue(fieldId, vscodeApi) {
 export function flipTile(fieldId) {
     let field = document.getElementById(fieldId);
   
-    let app = 'appearance';
-    if (field.getAttribute(app) === 'primary'){
-      field.setAttribute(app,'secondary');
+    if (field.getAttribute('appearance') === 'primary'){
+      setSecondary(field.id);
     } else {
-      field.setAttribute(app,'primary');
+      setPrimary(field.id);
     }
+}
+
+export function setPrimary(fieldId) {
+  let field = document.getElementById(fieldId);
+
+  // change appearance
+  field.setAttribute('appearance','primary');
+
+  //TODO: calculate multi value (lowest unused digit or 1)
+  //TODO: show multi field
+}
+
+export function setSecondary(fieldId) {
+  let field = document.getElementById(fieldId);
+
+  // change appearance
+  field.setAttribute('appearance','secondary');
+
+  //TODO: clear multi value
+  //TODO: hide multi field
 }
 
 export function checkScenarioFields() {
@@ -119,9 +138,9 @@ export function updateTiles(content) {
     let tiles = document.querySelectorAll(".modulartile");
     for (const tile of tiles) {
       if (currentElements.includes(tile.id)) {
-        tile.setAttribute('appearance','primary');
+        setPrimary(tile.id);
       } else {
-        tile.setAttribute('appearance','secondary');
+        setSecondary(tile.id);
       }
     }
 }

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -24,6 +24,12 @@ export function addScenarioEventListeners(vscodeApi) {
     field.addEventListener("change", changePackages);
   }
 
+  // multi fields
+  for (const field of document.querySelectorAll(".multifield")) {
+    // field.addEventListener("change",multiFieldChange(vscodeApi));
+    field.addEventListener("keyup",multiFieldChange(vscodeApi));
+  }
+
   // if modular: check currentInput content and update tiles
   if (isModular()) {
     updateTiles(currentInput.value);
@@ -40,6 +46,19 @@ export var clickTile = function (vscodeApi) { return function (event) {
       setPrimary(field.id,vscodeApi);
     }
 };};
+
+export var multiFieldChange = function (vscodeApi) { return  function (event) {
+  const field = event.target;
+
+  // save field value
+  var value = field.value;
+  var textString = field.id + '|' + (field.getAttribute('index') ?? '') + '|' + field.value;
+  vscodeApi.postMessage({ command: "savemultivalue", text: textString });
+
+  //TODO: update scenario in currentInput
+  
+};};
+
 
 export var scenarioFieldChange = function (vscodeApi) { return  function (event) {
     // passing parameter and event to listener function
@@ -127,8 +146,12 @@ export function setPrimary(fieldId,vscodeApi) {
   let multifield = document.querySelectorAll("#multifield" + fieldId);
   // vscodeApi.postMessage({ command: "setprime", text: multifield[0].id });
   if (multifield.length > 0) {
-    //calculate multi value (lowest unused digit or 1)
-    multifield[0].value = lowestUnusedDigitOr1() + "";
+    //calculate multi value (lowest unused digit or 1) unless already set
+    if (multifield[0].value === '') {
+      multifield[0].value = lowestUnusedDigitOr1() + "";
+      // trigger 'keyup' event to save and check content
+      multifield[0].dispatchEvent(new Event('keyup'));
+    }
 
     //show multi field
     //multifield[0].hidden = false;
@@ -161,6 +184,8 @@ export function setSecondary(fieldId,vscodeApi) {
 
     //clear multi value
     multifield[0].value = '';
+    // trigger 'keyup' event to save and check content
+    multifield[0].dispatchEvent(new Event('keyup'));
 
     //hide multi field
     //multifield[0].hidden = true;

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -45,7 +45,7 @@ export var clickTile = function (vscodeApi) { return function (event) {
     currentInput.dispatchEvent(new Event('change'));
   
     // update appearance on click
-    flipTile(field.id);
+    flipTile(field.id, vscodeApi);
 };};
 
 export var scenarioFieldChange = function (vscodeApi) { return  function (event) {
@@ -91,34 +91,67 @@ export function saveScenarioValue(fieldId, vscodeApi) {
     vscodeApi.postMessage({ command: "savevalue", text: textString });
 }
 
-export function flipTile(fieldId) {
+export function flipTile(fieldId, vscodeApi) {
     let field = document.getElementById(fieldId);
   
     if (field.getAttribute('appearance') === 'primary'){
-      setSecondary(field.id);
+      setSecondary(field.id,vscodeApi);
     } else {
-      setPrimary(field.id);
+      setPrimary(field.id,vscodeApi);
     }
 }
 
-export function setPrimary(fieldId) {
+export function lowestUnusedDigitOr1() {
+  let multifields = document.querySelectorAll(".multifield");
+  let concatenatedValues = '';
+  let lowestUnused = 0;
+  for (const multifield of multifields) {
+    concatenatedValues += multifield.value;
+  }
+
+  for (const digit of [...Array(9).keys()].map(x => ++x)) {
+    if (!concatenatedValues.includes(digit+"")) {
+      lowestUnused = digit;
+      break;
+    }
+  }
+
+  return (lowestUnused === 0) ? 1 : lowestUnused;
+}
+
+export function setPrimary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
 
   // change appearance
   field.setAttribute('appearance','primary');
 
-  //TODO: calculate multi value (lowest unused digit or 1)
-  //TODO: show multi field
+  let multifield = document.querySelectorAll("#multifield" + fieldId);
+  // vscodeApi.postMessage({ command: "setprime", text: multifield[0].id });
+  if (multifield.length > 0) {
+    //TODO: calculate multi value (lowest unused digit or 1)
+    multifield[0].value = lowestUnusedDigitOr1() + "";
+
+    //show multi field
+    //multifield[0].hidden = false;
+    multifield[0].disabled = false;
+  }
 }
 
-export function setSecondary(fieldId) {
+export function setSecondary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
 
   // change appearance
   field.setAttribute('appearance','secondary');
 
-  //TODO: clear multi value
-  //TODO: hide multi field
+  let multifield = document.querySelectorAll("#multifield" + fieldId);
+  if (multifield.length > 0) {
+
+    //TODO: clear multi value
+    multifield[0].value = '';
+    //hide multi field
+    //multifield[0].hidden = true;
+    multifield[0].disabled = true;
+  }
 }
 
 export function checkScenarioFields() {

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -119,8 +119,11 @@ export function setPrimary(fieldId,vscodeApi) {
 
   // add tile content to last selected scenario field
   let currentElements = currentInput.value.split('-');
-  if (!currentElements.includes(field.id)) {
-    currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? (base + '-') : '-') + field.id;
+  let regex = new RegExp('-' + field.id + '([-_]|$)',"g");
+  let check = currentInput.value.match(regex);
+  let addstring = field.id + (multifield.length > 0 ? '_' + multifield[0].value : '');
+  if (!check) {
+    currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? (base + '-') : '-') + addstring;
 
     // trigger 'change' event to save and check content
     currentInput.dispatchEvent(new Event('change'));
@@ -148,8 +151,13 @@ export function setSecondary(fieldId,vscodeApi) {
 
   // remove tile content from last selected scenario field
   let currentElements = currentInput.value.split('-');
-  if (currentElements.includes(field.id)) {
-    let newValue = currentElements.filter(el => el !== field.id).join('-');
+  let regex = new RegExp('-' + field.id + '([-_]|$)');
+  let check = currentInput.value.match(regex);
+  if (check) {
+    //let newValue = currentElements.filter(el => el !== field.id &&).join('-');
+    // replace if multi, else replace if not multi
+    let multiregex = new RegExp('-' + field.id + '_\\d+(-|$)');
+    let newValue = currentInput.value.replace(multiregex, '$1').replace(regex, check[1]);
     currentInput.value = (newValue === base) ? '' : newValue;
 
     // trigger 'change' event to save and check content
@@ -173,7 +181,9 @@ export function updateTiles(content) {
     
     let tiles = document.querySelectorAll(".modulartile");
     for (const tile of tiles) {
-      if (currentElements.includes(tile.id)) {
+      let regex = new RegExp('-' + tile.id + '([-_]|$)');
+      // if (currentElements.includes(tile.id)) {
+      if (content.match(regex)) {
         setPrimary(tile.id);
       } else {
         setSecondary(tile.id);

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -24,6 +24,11 @@ export function addScenarioEventListeners(vscodeApi) {
     field.addEventListener("change", changePackages(vscodeApi));
   }
 
+  // nofPackages dropdowns
+  for (const field of document.querySelectorAll(".nofpackages")) {
+    field.addEventListener("change", changePackagesDropdown(vscodeApi));
+  }
+
   // multi fields
   for (const field of document.querySelectorAll(".multifield")) {
     // field.addEventListener("change",multiFieldChange(vscodeApi));
@@ -82,6 +87,16 @@ export var scenarioFieldChange = function (vscodeApi) { return  function (event)
         updateScenarioFieldOutlineAndTooltip(sc.id);
       }
     }
+};};
+
+export var changePackagesDropdown = function (vscodeApi) { return  function (event) {
+    const nofPackagesField = event.target;
+    const nofPackages = nofPackagesField.value;
+
+    // save
+    vscodeApi.postMessage({ command: "savevalue", text: 'nofpackagesdropdown|' + nofPackagesField.getAttribute('index') + '|' + nofPackages });
+
+
 };};
   
 export var changePackages = function (vscodeApi) { return  function (event) {

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -30,7 +30,8 @@ export class CreateIntegrationHtmlObject {
     private _existingScenarioFieldValues: string[],
     private _existingScenarioCheckboxValues: boolean[],
     private _createUpdateValue: string,
-    private _modularValue: boolean 
+    private _modularValue: boolean,
+    private _multiFieldValues: {[details: string] : string;}
     ) { }
 
   // METHODS
@@ -50,7 +51,8 @@ export class CreateIntegrationHtmlObject {
       +this._fieldValues[nofScenariosIndex], 
       nofScenariosIndex,
       +this._fieldValues[nofPackagesIndex],
-      nofPackagesIndex
+      nofPackagesIndex,
+      this._multiFieldValues
     );
 
     // define panel HTML

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -31,7 +31,8 @@ export class CreateIntegrationHtmlObject {
     private _existingScenarioCheckboxValues: boolean[],
     private _createUpdateValue: string,
     private _modularValue: boolean,
-    private _multiFieldValues: {[details: string] : string;}
+    private _multiFieldValues: {[details: string] : string;},
+    private _nofPackages: string[]
     ) { }
 
   // METHODS
@@ -52,7 +53,8 @@ export class CreateIntegrationHtmlObject {
       nofScenariosIndex,
       +this._fieldValues[nofPackagesIndex],
       nofPackagesIndex,
-      this._multiFieldValues
+      this._multiFieldValues,
+      this._nofPackages
     );
 
     // define panel HTML

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -313,7 +313,7 @@ export class CreateIntegrationHtmlObject {
       html += /*html*/`
         <section class="component-example">
           <vscode-checkbox id="runexistingscenario${index}" class="existingscenariocheckbox" indexescheckbox="${index}" ${checked}></vscode-checkbox>
-          <vscode-text-field id="existingscenario${index}" size="40" class="existingscenariofield" value="${this._existingScenarioFieldValues[index]}" ${disabledReadonly}></vscode-text-field>
+          <vscode-text-field id="existingscenario${index}" class="existingscenariofield" value="${this._existingScenarioFieldValues[index]}" ${disabledReadonly}></vscode-text-field>
         </section>
       `;
     }

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -12,6 +12,7 @@ const nofStepsIndex = 5;
 const nofScenariosIndex = 6;
 const carrierUserIndex = 7;
 const carrierPwdIndex = 8;
+const nofPackagesIndex = 10;
 
 export class CreateIntegrationHtmlObject {
   // PROPERTIES
@@ -47,7 +48,9 @@ export class CreateIntegrationHtmlObject {
       this._scenarioFieldValues, 
       this._modularValue, 
       +this._fieldValues[nofScenariosIndex], 
-      nofScenariosIndex
+      nofScenariosIndex,
+      +this._fieldValues[nofPackagesIndex],
+      nofPackagesIndex
     );
 
     // define panel HTML

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -22,7 +22,7 @@ export class CreateIntegrationHtmlObject {
   public constructor(  
     private _uris: vscode.Uri[],  
     private _availableScenarios: string[], 
-    private _modularElementsWithParents: {parent:string, element:string}[],
+    private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[],
     private _fieldValues: string[],
     private _stepFieldValues: string[],
     private _otherStepValues: string[],

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -47,8 +47,7 @@ export class CreateIntegrationHtmlObject {
       this._scenarioFieldValues, 
       this._modularValue, 
       +this._fieldValues[nofScenariosIndex], 
-      nofScenariosIndex,
-      (this._createUpdateValue === 'update')
+      nofScenariosIndex
     );
 
     // define panel HTML

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -12,7 +12,6 @@ const nofStepsIndex = 5;
 const nofScenariosIndex = 6;
 const carrierUserIndex = 7;
 const carrierPwdIndex = 8;
-const nofPackagesIndex = 10;
 
 export class CreateIntegrationHtmlObject {
   // PROPERTIES
@@ -51,8 +50,6 @@ export class CreateIntegrationHtmlObject {
       this._modularValue, 
       +this._fieldValues[nofScenariosIndex], 
       nofScenariosIndex,
-      +this._fieldValues[nofPackagesIndex],
-      nofPackagesIndex,
       this._multiFieldValues,
       this._nofPackages
     );

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -133,6 +133,9 @@ export class CreateIntegrationPanel {
             var value = classIndexValue[2];
             switch (classIndexValue[0]) {
               case 'dropdown':
+                this._fieldValues[index] = value;
+                this._updateWebview(extensionUri);
+                break;
               case 'field':
                 this._fieldValues[index] = value;
                 break;

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -34,6 +34,7 @@ export class CreateIntegrationPanel {
   private _availableScenarios: string[] = [];
   private _modularElementsWithParents: {parent:string, element:string}[] = [];
   private _functionsPath: string = '';
+  private _multiFieldValues: {[details: string] : string;} = {};
 
   // constructor
   private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, nofSteps: number, context: vscode.ExtensionContext) {
@@ -127,6 +128,17 @@ export class CreateIntegrationPanel {
             this._scenarioFieldValues = [];
             break;
 
+          case "savemultivalue":
+            // extract
+            var idIndexValue = text.split('|');
+            var id = idIndexValue[0];
+            var index = +idIndexValue[1];
+            var value = idIndexValue[2];
+
+            // save
+            this._multiFieldValues[id] = value;
+            
+            break;
           case "savevalue":
             var classIndexValue = text.split('|');
             var index = +classIndexValue[1];
@@ -535,7 +547,8 @@ export class CreateIntegrationPanel {
       this._existingScenarioFieldValues,
       this._existingScenarioCheckboxValues,
       this._createUpdateValue,
-      this._modularValue
+      this._modularValue,
+      this._multiFieldValues
     );
 
     let html =  createIntegrationHtmlObject.getHtml();

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -169,6 +169,9 @@ export class CreateIntegrationPanel {
                 this._scenarioFieldValues = [];
                 this._updateWebview(extensionUri);
                 break;
+              case 'nofpackages':
+                this._fieldValues[index] = value;
+                break;
             }
         }
       },

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -13,6 +13,7 @@ const nofStepsIndex = 5;
 const nofScenariosIndex = 6;
 const carrierUserIndex = 7;
 const carrierPwdIndex = 8;
+const nofPackagesIndex = 10;
 
 export class CreateIntegrationPanel {
   // PROPERTIES
@@ -42,6 +43,7 @@ export class CreateIntegrationPanel {
     this._fieldValues[moduleIndex] = 'booking';
     this._fieldValues[nofStepsIndex] = "1";
     this._fieldValues[nofScenariosIndex] = "1";
+    this._fieldValues[nofPackagesIndex] = "1";
 
     // set content
     this._getWebviewContent(this._panel.webview, extensionUri).then(html => this._panel.webview.html = html);

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -13,7 +13,6 @@ const nofStepsIndex = 5;
 const nofScenariosIndex = 6;
 const carrierUserIndex = 7;
 const carrierPwdIndex = 8;
-const nofPackagesIndex = 10;
 
 export class CreateIntegrationPanel {
   // PROPERTIES
@@ -45,7 +44,6 @@ export class CreateIntegrationPanel {
     this._fieldValues[moduleIndex] = 'booking';
     this._fieldValues[nofStepsIndex] = "1";
     this._fieldValues[nofScenariosIndex] = "1";
-    this._fieldValues[nofPackagesIndex] = "1";
 
     // set content
     this._getWebviewContent(this._panel.webview, extensionUri).then(html => this._panel.webview.html = html);
@@ -169,9 +167,6 @@ export class CreateIntegrationPanel {
                 this._modularValue = toBoolean(value);
                 this._scenarioFieldValues = [];
                 this._updateWebview(extensionUri);
-                break;
-              case 'nofpackages':
-                this._fieldValues[index] = value;
                 break;
               case 'nofpackagesdropdown':
                 this._nofPackages[index] = value;

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -35,6 +35,7 @@ export class CreateIntegrationPanel {
   private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[] = [];
   private _functionsPath: string = '';
   private _multiFieldValues: {[details: string] : string;} = {};
+  private _nofPackages: string[] = [];
 
   // constructor
   private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, nofSteps: number, context: vscode.ExtensionContext) {
@@ -171,6 +172,9 @@ export class CreateIntegrationPanel {
                 break;
               case 'nofpackages':
                 this._fieldValues[index] = value;
+                break;
+              case 'nofpackagesdropdown':
+                this._nofPackages[index] = value;
                 break;
             }
         }
@@ -551,7 +555,8 @@ export class CreateIntegrationPanel {
       this._existingScenarioCheckboxValues,
       this._createUpdateValue,
       this._modularValue,
-      this._multiFieldValues
+      this._multiFieldValues,
+      this._nofPackages
     );
 
     let html =  createIntegrationHtmlObject.getHtml();

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -32,7 +32,7 @@ export class CreateIntegrationPanel {
   private _emptyIntegrationObject : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]} = {path: '', carrier: '', api: '', module: '', carriercode: '', modular: false, scenarios: [], validscenarios:[]};
   private _currentIntegration :     {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]} = this._emptyIntegrationObject;
   private _availableScenarios: string[] = [];
-  private _modularElementsWithParents: {parent:string, element:string}[] = [];
+  private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[] = [];
   private _functionsPath: string = '';
   private _multiFieldValues: {[details: string] : string;} = {};
 

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -30,7 +30,7 @@ export class CreatePostmanCollectionHtmlObject {
     private _carrierCodes: {carrier: string,  carriercode: string }[] = [],
     private _scenarioFieldValues: string[],
     private _availableScenarios: string[], 
-    private _modularElementsWithParents: {parent:string, element:string}[],
+    private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[],
     private _independent: boolean,
     private _modularValue: boolean,
     private _multiFieldValues: {[details: string] : string;}

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -12,7 +12,6 @@ const accountNumberIndex = 5;
 const costCenterIndex = 6;
 const nofScenariosIndex = 7;
 const carrierCodeIndex = 8;
-const nofPackagesIndex = 10;
 
 export class CreatePostmanCollectionHtmlObject {
   // PROPERTIES
@@ -53,8 +52,6 @@ export class CreatePostmanCollectionHtmlObject {
       this._modularValue, 
       +this._fieldValues[nofScenariosIndex], 
       nofScenariosIndex,
-      +this._fieldValues[nofPackagesIndex],
-      nofPackagesIndex,
       this._multiFieldValues,
       this._nofPackages
     );

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -12,6 +12,7 @@ const accountNumberIndex = 5;
 const costCenterIndex = 6;
 const nofScenariosIndex = 7;
 const carrierCodeIndex = 8;
+const nofPackagesIndex = 10;
 
 export class CreatePostmanCollectionHtmlObject {
   // PROPERTIES
@@ -49,7 +50,9 @@ export class CreatePostmanCollectionHtmlObject {
       this._scenarioFieldValues, 
       this._modularValue, 
       +this._fieldValues[nofScenariosIndex], 
-      nofScenariosIndex
+      nofScenariosIndex,
+      +this._fieldValues[nofPackagesIndex],
+      nofPackagesIndex
     );
 
     // define panel HTML

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -33,7 +33,8 @@ export class CreatePostmanCollectionHtmlObject {
     private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[],
     private _independent: boolean,
     private _modularValue: boolean,
-    private _multiFieldValues: {[details: string] : string;}
+    private _multiFieldValues: {[details: string] : string;},
+    private _nofPackages: string[]
   ) { }
 
   // METHODS
@@ -54,7 +55,8 @@ export class CreatePostmanCollectionHtmlObject {
       nofScenariosIndex,
       +this._fieldValues[nofPackagesIndex],
       nofPackagesIndex,
-      this._multiFieldValues
+      this._multiFieldValues,
+      this._nofPackages
     );
 
     // define panel HTML

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -32,7 +32,8 @@ export class CreatePostmanCollectionHtmlObject {
     private _availableScenarios: string[], 
     private _modularElementsWithParents: {parent:string, element:string}[],
     private _independent: boolean,
-    private _modularValue: boolean
+    private _modularValue: boolean,
+    private _multiFieldValues: {[details: string] : string;}
   ) { }
 
   // METHODS
@@ -52,7 +53,8 @@ export class CreatePostmanCollectionHtmlObject {
       +this._fieldValues[nofScenariosIndex], 
       nofScenariosIndex,
       +this._fieldValues[nofPackagesIndex],
-      nofPackagesIndex
+      nofPackagesIndex,
+      this._multiFieldValues
     );
 
     // define panel HTML

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -33,7 +33,7 @@ export class CreatePostmanCollectionPanel {
   private _independent: boolean = false;
   private _modularValue: boolean = false;
   private _multiFieldValues: {[details: string] : string;} = {};
-
+  private _nofPackages: string[] = [];
   private _integrationObjects: {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}[] = [];
   private _emptyIntegrationObject : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]} = {path: '', carrier: '', api: '', module: '', carriercode: '', modular: false, scenarios: [], validscenarios:[]};
   private _codeCompanies: {
@@ -251,6 +251,10 @@ export class CreatePostmanCollectionPanel {
 
               case 'nofpackages':
                 this._fieldValues[index] = value;
+                break;
+
+              case 'nofpackagesdropdown':
+                this._nofPackages[index] = value;
                 break;
 
               case 'scenariofield':
@@ -547,7 +551,8 @@ export class CreatePostmanCollectionPanel {
       this._modularElementsWithParents,
       this._independent,
       this._modularValue,
-      this._multiFieldValues
+      this._multiFieldValues,
+      this._nofPackages
     );
 
     let html =  createPostmanCollectionHtmlObject.getHtml();

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -29,7 +29,7 @@ export class CreatePostmanCollectionPanel {
   private _modules: string[] = [];
   private _scenarioFieldValues: string[] = [];
   private _availableScenarios: string[] = [];
-  private _modularElementsWithParents: {parent:string, element:string}[] = [];
+  private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[] = [];
   private _independent: boolean = false;
   private _modularValue: boolean = false;
   private _multiFieldValues: {[details: string] : string;} = {};

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -249,6 +249,10 @@ export class CreatePostmanCollectionPanel {
                 this._updateWebview(extensionUri);
                 break;
 
+              case 'nofpackages':
+                this._fieldValues[index] = value;
+                break;
+
               case 'scenariofield':
                 this._scenarioFieldValues[index] = value;
                 break;

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -14,6 +14,7 @@ const accountNumberIndex = 5;
 const costCenterIndex = 6;
 const nofScenariosIndex = 7;
 const carrierCodeIndex = 8;
+const nofPackagesIndex = 10;
 
 export class CreatePostmanCollectionPanel {
   // PROPERTIES

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -32,6 +32,7 @@ export class CreatePostmanCollectionPanel {
   private _modularElementsWithParents: {parent:string, element:string}[] = [];
   private _independent: boolean = false;
   private _modularValue: boolean = false;
+  private _multiFieldValues: {[details: string] : string;} = {};
 
   private _integrationObjects: {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}[] = [];
   private _emptyIntegrationObject : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]} = {path: '', carrier: '', api: '', module: '', carriercode: '', modular: false, scenarios: [], validscenarios:[]};
@@ -137,6 +138,17 @@ export class CreatePostmanCollectionPanel {
             vscode.window.showInformationMessage(text);
             break;
 
+          case "savemultivalue":
+            // extract
+            var idIndexValue = text.split('|');
+            var id = idIndexValue[0];
+            var index = +idIndexValue[1];
+            var value = idIndexValue[2];
+
+            // save
+            this._multiFieldValues[id] = value;
+            
+            break;
           case "savevalue":
             var classIndexValue = text.split('|');
             var clas = classIndexValue[0];
@@ -530,7 +542,8 @@ export class CreatePostmanCollectionPanel {
       this._availableScenarios,
       this._modularElementsWithParents,
       this._independent,
-      this._modularValue
+      this._modularValue,
+      this._multiFieldValues
     );
 
     let html =  createPostmanCollectionHtmlObject.getHtml();

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -14,7 +14,6 @@ const accountNumberIndex = 5;
 const costCenterIndex = 6;
 const nofScenariosIndex = 7;
 const carrierCodeIndex = 8;
-const nofPackagesIndex = 10;
 
 export class CreatePostmanCollectionPanel {
   // PROPERTIES
@@ -247,10 +246,6 @@ export class CreatePostmanCollectionPanel {
                 this._modularValue = toBoolean(value);
                 this._scenarioFieldValues = [];
                 this._updateWebview(extensionUri);
-                break;
-
-              case 'nofpackages':
-                this._fieldValues[index] = value;
                 break;
 
               case 'nofpackagesdropdown':

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import {  dropdownOptions, toBoolean, uniqueArray, uniqueSort, arrayFrom1, arrayFrom0, nth, checkedString, valueString, readonlyString} from "./functions";
+import {  dropdownOptions, toBoolean, uniqueArray, uniqueSort, arrayFrom1, arrayFrom0, nth, checkedString, valueString, readonlyString, hiddenString} from "./functions";
 
 
 export class ScenarioGridObject {
@@ -13,7 +13,10 @@ export class ScenarioGridObject {
         private _scenarioFieldValues: string[],
         private _modularValue: boolean,
         private _nofScenarios: number,
-        private _nofScenariosIndex: number
+        private _nofScenariosIndex: number,
+        private _multiValue: boolean = true,
+        private _nofPackages: number = 5,
+        private _nofPackagesIndex: number = 10
     ) { }
 
     public getHtml(): string {
@@ -30,6 +33,8 @@ export class ScenarioGridObject {
 
                         <section class="component-example">
                             <vscode-checkbox id="modular" class="modular" ${checkedString(this._modularValue)}>Modular</vscode-checkbox>
+                            <vscode-checkbox id="multi" class="multi" ${checkedString(this._multiValue)} ${hiddenString(this._modularValue)}>Multi</vscode-checkbox>
+                            <vscode-text-field id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} class="field" ${hiddenString(this._multiValue)}></vscode-text-field>
                         </section>
 
                         <vscode-divider role="separator"></vscode-divider>
@@ -109,6 +114,7 @@ export class ScenarioGridObject {
         let testButton: string = /*html*/ `
         <section class="component-example">
             <vscode-button id="${id}" class="modulartile" appearance="secondary">${id}</vscode-button>
+            
         </section>
         `;
         return testButton;

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -13,8 +13,7 @@ export class ScenarioGridObject {
         private _scenarioFieldValues: string[],
         private _modularValue: boolean,
         private _nofScenarios: number,
-        private _nofScenariosIndex: number,
-        private _isUpdate: boolean = false
+        private _nofScenariosIndex: number
     ) { }
 
     public getHtml(): string {
@@ -83,14 +82,14 @@ export class ScenarioGridObject {
     private _getModularTiles() : string {
         let html : string = ``;
             // cycle through modular element parent folders
-            let parents = uniqueSort(this._modularElementsWithParents.map(el => el.parent));
+            let parents = uniqueSort(this._modularElementsWithParents.map(el => el.parent)).filter(el => el !== '');
             for (const parent of parents) {
                 let modularTiles = '';
                 
                 // cycle through elements in given parent folder
                 let elements = this._modularElementsWithParents.filter(el => el.parent === parent).map(el => el.element).sort();
                 for (const element of elements) {
-                    modularTiles += (element === 'm') ? '' : this._getModularTile(element);
+                    modularTiles += this._getModularTile(element);
                 }
 
                 // add to html

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -126,16 +126,6 @@ export class ScenarioGridObject {
         return html;
     }
 
-    private _getModularTile(id:string): string {
-        let testButton: string = /*html*/ `
-        <section class="component-example">
-            <vscode-button id="${id}" class="modulartile" appearance="secondary">${id}</vscode-button>
-            
-        </section>
-        `;
-        return testButton;
-    }
-
     private _getCleanParent(parent:string) : string {
         return parent.replace(/[\s\S]*\_/g,'');
     }

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -15,9 +15,8 @@ export class ScenarioGridObject {
         private _modularValue: boolean,
         private _nofScenarios: number,
         private _nofScenariosIndex: number,
-        private _multiValue: boolean = true,
-        private _nofPackages: number = 5,
-        private _nofPackagesIndex: number = 10,
+        private _nofPackages: number,
+        private _nofPackagesIndex: number,
         private _multiFieldValues: string[] = []
     ) { }
 
@@ -35,8 +34,7 @@ export class ScenarioGridObject {
 
                         <section class="component-example">
                             <vscode-checkbox id="modular" class="modular" ${checkedString(this._modularValue)}>Modular</vscode-checkbox>
-                            <vscode-checkbox id="multi" class="multi" ${checkedString(this._multiValue)} ${hiddenString(this._modularValue)}>Multi</vscode-checkbox>
-                            <vscode-text-field id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} class="field" ${hiddenString(this._multiValue)}></vscode-text-field>
+                            ${this._modularValue ? this._nofPackagesField() : ''}
                         </section>
 
                         <vscode-divider role="separator"></vscode-divider>
@@ -72,6 +70,12 @@ export class ScenarioGridObject {
         }
 
         return html;
+    }
+
+    private _nofPackagesField() : string {
+        return /*html*/ `
+        <p>Number of Packages</p>
+        <vscode-text-field id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} class="field"></vscode-text-field>`;
     }
 
     private _getScenarioInputField(index:number) : string {

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -14,10 +14,8 @@ export class ScenarioGridObject {
         private _modularValue: boolean,
         private _nofScenarios: number,
         private _nofScenariosIndex: number,
-        private _nofPackages: number,
-        private _nofPackagesIndex: number,
         private _multiFieldValues: {[details: string] : string;},
-        private _nofPackagesDropdowns: string[]
+        private _nofPackages: string[]
     ) { }
 
     public getHtml(): string {
@@ -34,7 +32,6 @@ export class ScenarioGridObject {
 
                         <section class="component-example">
                             <vscode-checkbox id="modular" class="modular" ${checkedString(this._modularValue)}>Modular</vscode-checkbox>
-                            ${this._modularValue ? this._nofPackagesField() : ''}
                         </section>
 
                         <vscode-divider role="separator"></vscode-divider>
@@ -80,7 +77,7 @@ export class ScenarioGridObject {
             scenarioNames += this._getScenarioInputField(scenario);
             multiDropdowns += /*html*/ `
                 <section class="component-example">
-                    <vscode-dropdown id="nofpackages${scenario}" class ="nofpackages" index="${scenario}" ${valueString(this._nofPackagesDropdowns[scenario] ?? '1')} position="below">
+                    <vscode-dropdown id="nofpackages${scenario}" class ="nofpackages" index="${scenario}" ${valueString(this._nofPackages[scenario] ?? '1')} position="below">
                         ${dropdownOptions(arrayFrom1(9))}
                     </vscode-dropdown>
                 </section>`;
@@ -101,13 +98,6 @@ export class ScenarioGridObject {
                 ${scenarioNames}
             </section>
         </section>`;
-    }
-
-    private _nofPackagesField() : string {
-        return /*html*/ ` Number of packages: 
-        <vscode-dropdown id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} position="below">
-            ${dropdownOptions(arrayFrom1(9))}
-        </vscode-dropdown>`;
     }
 
     private _getScenarioInputField(index:number) : string {

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -73,9 +73,10 @@ export class ScenarioGridObject {
     }
 
     private _nofPackagesField() : string {
-        return /*html*/ `
-        <p>Number of Packages</p>
-        <vscode-text-field id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} class="field"></vscode-text-field>`;
+        return /*html*/ ` Number of packages: 
+        <vscode-dropdown id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} class="dropdown" position="below">
+            ${dropdownOptions(arrayFrom1(9))}
+        </vscode-dropdown>`;
     }
 
     private _getScenarioInputField(index:number) : string {

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -74,7 +74,7 @@ export class ScenarioGridObject {
 
     private _nofPackagesField() : string {
         return /*html*/ ` Number of packages: 
-        <vscode-dropdown id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} class="dropdown" position="below">
+        <vscode-dropdown id="nofpackages" index="${this._nofPackagesIndex}" ${valueString(this._nofPackages + '')} position="below">
             ${dropdownOptions(arrayFrom1(9))}
         </vscode-dropdown>`;
     }

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -5,12 +5,11 @@ import {  dropdownOptions, toBoolean, uniqueArray, uniqueSort, arrayFrom1, array
 export class ScenarioGridObject {
     // PROPERTIES
     public static currentScenarioGridObject: ScenarioGridObject | undefined;
-    private _multiParents: string[] = ['dangerous'];
 
     // constructor
     public constructor (
         private _availableScenarios: string[],
-        private _modularElementsWithParents: {parent:string, element:string}[],
+        private _modularElementsWithParents: {parent:string, element:string, multi:boolean}[],
         private _scenarioFieldValues: string[],
         private _modularValue: boolean,
         private _nofScenarios: number,
@@ -102,10 +101,14 @@ export class ScenarioGridObject {
                 // cycle through elements in given parent folder
                 let elements = this._modularElementsWithParents.filter(el => el.parent === parent).map(el => el.element).sort();
                 for (const element of elements) {
+                    // get current modularElements object
+                    let currentElementObject = this._modularElementsWithParents.filter(el => el.parent === parent && el.element === element)[0];
+
+                    // build modular tile (and add multifield, if appropriate)
                     modularTiles += /*html*/ `
                     <section class="component-example">
                         <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
-                        ${this._multiParents.includes(this._getCleanParent(parent)) ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" disabled></vscode-text-field>` : ''}
+                        ${ currentElementObject.multi ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" disabled></vscode-text-field>` : ''}
                     </section>
                     `;
                 }

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -133,7 +133,9 @@ export class ScenarioGridObject {
                     modularTiles += /*html*/ `
                     <section class="component-example">
                         <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
-                        ${ currentElementObject.multi ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>` : ''}
+                        ${ currentElementObject.multi ? /*html*/ `
+                            <vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>
+                        ` : ''}
                     </section>
                     `;
                 }

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -45,7 +45,7 @@ export class ScenarioGridObject {
                             </vscode-dropdown>
                         </section>
 
-                        ${this._scenarioInputs()}
+                        ${this._modularValue ? this._modularScenarioInputs() : this._fixedScenarioInputs()}
                     </div>                    
                 ${this._modularValue ? '</div>' : ''}
                 ${this._modularValue ? '<div class="floatleft">' : ''}
@@ -58,17 +58,44 @@ export class ScenarioGridObject {
         return scenariosGrid;
     }
 
-    private _scenarioInputs(): string {
+    private _fixedScenarioInputs(): string {
         let html: string = ``;
 
         for (let scenario = 0; scenario < +this._nofScenarios; scenario++) {
             html += /*html*/`
             <section class="component-example">
-                ${this._modularValue ? this._getScenarioInputField(scenario) : this._getScenarioDropdown(scenario)}
+                ${this._getScenarioDropdown(scenario)}
             </section>`;
         }
 
         return html;
+    }
+
+    private _modularScenarioInputs(): string {
+        
+        let scenarioNames: string = ``;
+        let multiDropdowns: string = ``;
+        for (let scenario = 0; scenario < +this._nofScenarios; scenario++) {
+            scenarioNames += this._getScenarioInputField(scenario);
+            multiDropdowns += /*html*/ `
+                <section class="component-example">
+                    <vscode-dropdown id="nofpackages${scenario}" index="${scenario}" ${valueString("1")} position="below">
+                        ${dropdownOptions(arrayFrom1(9))}
+                    </vscode-dropdown>
+                </section>`;
+        }
+
+        return /*html*/`
+        <section class="component-example">
+            <section class="floatleftnopadding">
+                <p># Packages</p>
+                ${multiDropdowns}
+            </section>
+            <section class="floatleftnopadding">
+                <p>Scenario name</p>
+                ${scenarioNames}
+            </section>
+        </section>`;
     }
 
     private _nofPackagesField() : string {
@@ -79,7 +106,10 @@ export class ScenarioGridObject {
     }
 
     private _getScenarioInputField(index:number) : string {
-        return /*html*/ `<vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" placeholder="${(index + 1) + nth(index + 1)} scenario name..." readonly></vscode-text-field>`;
+        return /*html*/ `
+        <section class="component-example">
+            <vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" placeholder="${(index + 1) + nth(index + 1)} scenario name..." readonly></vscode-text-field>
+        </section>`;
     }
 
     private _getScenarioDropdown(index:number) : string {

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -16,7 +16,8 @@ export class ScenarioGridObject {
         private _nofScenariosIndex: number,
         private _nofPackages: number,
         private _nofPackagesIndex: number,
-        private _multiFieldValues: {[details: string] : string;}
+        private _multiFieldValues: {[details: string] : string;},
+        private _nofPackagesDropdowns: string[]
     ) { }
 
     public getHtml(): string {
@@ -79,7 +80,7 @@ export class ScenarioGridObject {
             scenarioNames += this._getScenarioInputField(scenario);
             multiDropdowns += /*html*/ `
                 <section class="component-example">
-                    <vscode-dropdown id="nofpackages${scenario}" index="${scenario}" ${valueString("1")} position="below">
+                    <vscode-dropdown id="nofpackages${scenario}" class ="nofpackages" index="${scenario}" ${valueString(this._nofPackagesDropdowns[scenario] ?? '1')} position="below">
                         ${dropdownOptions(arrayFrom1(9))}
                     </vscode-dropdown>
                 </section>`;
@@ -88,11 +89,15 @@ export class ScenarioGridObject {
         return /*html*/`
         <section class="component-example">
             <section class="floatleftnopadding">
-                <p># Packages</p>
+                <section class="component-example">
+                    <p># Packages</p>
+                </section>
                 ${multiDropdowns}
             </section>
             <section class="floatleftnopadding">
-                <p>Scenario name</p>
+                <section class="component-example">
+                    <p>Scenario name</p>
+                </section>
                 ${scenarioNames}
             </section>
         </section>`;

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -108,7 +108,7 @@ export class ScenarioGridObject {
                     modularTiles += /*html*/ `
                     <section class="component-example">
                         <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
-                        ${ currentElementObject.multi ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" hidden></vscode-text-field>` : ''}
+                        ${ currentElementObject.multi ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>` : ''}
                     </section>
                     `;
                 }

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -17,7 +17,7 @@ export class ScenarioGridObject {
         private _nofScenariosIndex: number,
         private _nofPackages: number,
         private _nofPackagesIndex: number,
-        private _multiFieldValues: string[] = []
+        private _multiFieldValues: {[details: string] : string;}
     ) { }
 
     public getHtml(): string {
@@ -96,7 +96,6 @@ export class ScenarioGridObject {
             // cycle through modular element parent folders
             let parents = uniqueSort(this._modularElementsWithParents.map(el => el.parent)).filter(el => el !== '');
 
-            let multiFieldIndex = 0;
             for (const parent of parents) {
                 let modularTiles = '';
                 
@@ -106,14 +105,9 @@ export class ScenarioGridObject {
                     modularTiles += /*html*/ `
                     <section class="component-example">
                         <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
-                        ${this._multiParents.includes(this._getCleanParent(parent)) ? /*html*/ `<vscode-text-field id="multifield${element}" index="${multiFieldIndex}" ${valueString(this._multiFieldValues[multiFieldIndex])} class="multifield" disabled></vscode-text-field>` : ''}
+                        ${this._multiParents.includes(this._getCleanParent(parent)) ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" disabled></vscode-text-field>` : ''}
                     </section>
                     `;
-
-                    // up counter if necessary
-                    if(this._multiParents.includes(this._getCleanParent(parent))) {
-                        multiFieldIndex++;
-                    }
                 }
 
                 // add to html

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -108,7 +108,7 @@ export class ScenarioGridObject {
                     modularTiles += /*html*/ `
                     <section class="component-example">
                         <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
-                        ${ currentElementObject.multi ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" disabled></vscode-text-field>` : ''}
+                        ${ currentElementObject.multi ? /*html*/ `<vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" hidden></vscode-text-field>` : ''}
                     </section>
                     `;
                 }

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -5,6 +5,7 @@ import {  dropdownOptions, toBoolean, uniqueArray, uniqueSort, arrayFrom1, array
 export class ScenarioGridObject {
     // PROPERTIES
     public static currentScenarioGridObject: ScenarioGridObject | undefined;
+    private _multiParents: string[] = ['dangerous'];
 
     // constructor
     public constructor (
@@ -16,7 +17,8 @@ export class ScenarioGridObject {
         private _nofScenariosIndex: number,
         private _multiValue: boolean = true,
         private _nofPackages: number = 5,
-        private _nofPackagesIndex: number = 10
+        private _nofPackagesIndex: number = 10,
+        private _multiFieldValues: string[] = []
     ) { }
 
     public getHtml(): string {
@@ -88,20 +90,32 @@ export class ScenarioGridObject {
         let html : string = ``;
             // cycle through modular element parent folders
             let parents = uniqueSort(this._modularElementsWithParents.map(el => el.parent)).filter(el => el !== '');
+
+            let multiFieldIndex = 0;
             for (const parent of parents) {
                 let modularTiles = '';
                 
                 // cycle through elements in given parent folder
                 let elements = this._modularElementsWithParents.filter(el => el.parent === parent).map(el => el.element).sort();
                 for (const element of elements) {
-                    modularTiles += this._getModularTile(element);
+                    modularTiles += /*html*/ `
+                    <section class="component-example">
+                        <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
+                        ${this._multiParents.includes(this._getCleanParent(parent)) ? /*html*/ `<vscode-text-field id="multifield${element}" index="${multiFieldIndex}" ${valueString(this._multiFieldValues[multiFieldIndex])} class="multifield" disabled></vscode-text-field>` : ''}
+                    </section>
+                    `;
+
+                    // up counter if necessary
+                    if(this._multiParents.includes(this._getCleanParent(parent))) {
+                        multiFieldIndex++;
+                    }
                 }
 
                 // add to html
                 html += /*html*/ `
                     <div class="floatleftlesspadding">
                         <section class="component-example">
-                            <h3>${parent.replace(/[\s\S]*\_/g,'')}</h3>
+                            <h3>${this._getCleanParent(parent)}</h3>
                         </section>
                             ${modularTiles}
                     </div>`;
@@ -118,6 +132,10 @@ export class ScenarioGridObject {
         </section>
         `;
         return testButton;
+    }
+
+    private _getCleanParent(parent:string) : string {
+        return parent.replace(/[\s\S]*\_/g,'');
     }
 
 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -71,27 +71,33 @@ export async function getModularElements(module:string): Promise<string[]> {
     return elements.sort();
 }
 
-export async function getModularElementsWithParents(module:string): Promise<{parent:string, element:string}[]> {
+export async function getModularElementsWithParents(module:string): Promise<{parent:string, element:string, multi:boolean}[]> {
     let elementXmls: string[] = await getWorkspaceFiles('**/scenario-templates/modular/' + module + '/**/*.xml');
-
-    let parentsElements: {parent:string, element:string}[] = new Array<{parent:string, element:string}>(elementXmls.length);
+    let parentsElementsMulti: {parent:string, element:string, multi:boolean}[] = new Array<{parent:string, element:string, multi:boolean}>(elementXmls.length);
 
     for (let index = 0; index < elementXmls.length; index++) {
+	  // element, parent
       let elementName = (cleanPath(elementXmls[index]).split('/').pop() ?? '').replace(/.xml$/, '');
       let elementParentName = parentPath(cleanPath(elementXmls[index])).split('/').pop() ?? '';
-      // only show parent indicator if not [module]
+
+	  // only show parent indicator if not [module]
       if (elementParentName === module) {
         elementParentName = '';
       }
 
-
-      parentsElements[index] = {
+	  // read file to extract multi
+	  let elementContent = fs.readFileSync(elementXmls[index], 'utf8');
+	  let multi = elementContent.includes('<ShipmentPackage>');
+      
+	  // build output
+      parentsElementsMulti[index] = {
 		parent: elementParentName,
-		element: elementName
+		element: elementName, 
+		multi: multi
 	  };
     }
 
-    return parentsElements.sort();
+    return parentsElementsMulti.sort();
 }
 
 export async function getAvailableIntegrations(panel:string) : Promise<{path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}[]> {

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -54,21 +54,7 @@ export async function getAvailableScenarios(module:string, withParent:boolean = 
 }
 
 export async function getModularElements(module:string): Promise<string[]> {
-    let elementXmls: string[] = await getWorkspaceFiles('**/scenario-templates/modular/' + module + '/**/*.xml');
-
-    let elements: string[] = new Array<string>(elementXmls.length);
-
-    for (let index = 0; index < elementXmls.length; index++) {
-      let elementName = (cleanPath(elementXmls[index]).split('/').pop() ?? '').replace(/.xml$/, '');
-      let elementParentName = parentPath(cleanPath(elementXmls[index])).split('/').pop() ?? '';
-      // only show parent indicator if not [module]
-      if (elementParentName === module) {
-        elementParentName = '';
-      }
-      elements[index] = elementName;
-    }
-
-    return elements.sort();
+    return (await getModularElementsWithParents(module)).map(el => el.element).sort();
 }
 
 export async function getModularElementsWithParents(module:string): Promise<{parent:string, element:string, multi:boolean}[]> {
@@ -137,7 +123,6 @@ export async function getAvailableIntegrations(panel:string) : Promise<{path:str
 				continue;
 			}
 		}
-		
 
 		// obtain valid scenarios from scenarios folder
 		let scenarioDir = fs.readdirSync(parentPath(cleanPath(script)) + `/${api}/${module}/scenarios`);
@@ -172,7 +157,7 @@ export function isScenarioValid(scenario:string, availableScenarios: string[], m
 	if (modular) {
 		let currentElements = scenario.split('-');
 		for (const element of currentElements) {
-			if (!modularElements.includes(element)) {
+			if (!modularElements.includes(element.replace(/\_\d+/g,''))) {
 				isValid = false;
 				break;
 			}


### PR DESCRIPTION
## 1.4.0 
- Modular Scenarios (general)
  - Modular scenario generation is now multi-package compatible
    - Supports up to 9 packages per scenario
    - Number of packages settable per scenario
      - Auto-adds and updates `multi` element with set number of packages to each scenario
    - Auto-detects which elements contain a `<ShipmentPackage>` node, and auto-adds package indices field upon tile selection
    - Field value checks on scenario and package indices field levels
      - checks if package indices between 1 and scenario-set number of packages, and no doubles present (and not empty)
      - Adds appropriate red field outline and hover-over tooltips
      - Does not allow integration creation/update or postman collection creation if any invalid fields
  - Updated tile view
    - Now lined up vertically to the right of the scenario list, with parent folder name auto-added as tile list header
    - Any element in root folder is not shown (reserved for auto-added elements like `m` and `multi`)