### PR TITLE
Allow custom scenario names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 1.5.1
+- Modular scenarios
+  - Now allows customised modular scenario names
+  - Now allows multiple modular tiles with the same name (as long as they are in different subfolders)
+  - Integration: existing scenarios
+    - Now shows which existing scenarios are modular (since cannot be deduced anymore from name)
+    - When existing modular scenario is checked, selecting the existing scenario name field will show which modular tiles it consists of
+
+- fix
+  - Now checks if new fixed scenario is not selected twice
+  - Integration: now hides carrier code field on 'update'
+- style
+  - Integration: on 'update', existing scenarios are now on the left, right under the carrier details
+
 ## 1.5.0 
 - Integration
   - Removed unused fields (urls, apy description, test user/pwd)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/createintegration/main.js
+++ b/scripts/createintegration/main.js
@@ -64,17 +64,17 @@ function fieldChange(event) {
     // existingscenariocheckbox: update associated existing scenario field
     case 'existingscenariocheckbox':
       var scenarioId = field.id.slice(3, field.id.length);
-      var scenario = document.getElementById(scenarioId);
+      // var scenario = document.getElementById(scenarioId);
       var scenarioname = document.getElementById(scenarioId.replace('scenario','scenariocustom'));
       if (field.checked) {
-        scenario.readOnly = true;
+        // scenario.readOnly = true;
         scenarioname.readOnly = true;
-        scenario.disabled = false;
+        // scenario.disabled = false;
         scenarioname.disabled = false;
       } else {
-        scenario.disabled = true;
+        // scenario.disabled = true;
         scenarioname.disabled = true;
-        scenario.readOnly = false;
+        // scenario.readOnly = false;
         scenarioname.readOnly = false;
       }
       break;

--- a/scripts/createintegration/main.js
+++ b/scripts/createintegration/main.js
@@ -65,12 +65,17 @@ function fieldChange(event) {
     case 'existingscenariocheckbox':
       var scenarioId = field.id.slice(3, field.id.length);
       var scenario = document.getElementById(scenarioId);
+      var scenarioname = document.getElementById(scenarioId.replace('scenario','scenariocustom'));
       if (field.checked) {
         scenario.readOnly = true;
+        scenarioname.readOnly = true;
         scenario.disabled = false;
+        scenarioname.disabled = false;
       } else {
         scenario.disabled = true;
+        scenarioname.disabled = true;
         scenario.readOnly = false;
+        scenarioname.readOnly = false;
       }
       break;
 

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -93,9 +93,12 @@ h1 {
   width: 10rem;
 }
 
-.scenariofield,
-.scenariocustomfield {
+.scenariofield {
   width: 25rem;
+}
+
+.scenariocustomfield {
+  width: 23rem;
 }
 
 #nofpackages{

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -93,7 +93,8 @@ h1 {
   width: 10rem;
 }
 
-.scenariofield {
+.scenariofield,
+.scenariocustomfield {
   width: 25rem;
 }
 

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -201,6 +201,8 @@ function updateModularValue(fieldId, newValue) {
   let custom = document.getElementById(field.id.replace('scenario','scenariocustom'));
   if (isEmpty(custom.value) || (custom.value === curCleanValue) ) {
     custom.value = newCleanValue;
+    // trigger 'keyup' event to save and check content
+    custom.dispatchEvent(new Event('keyup'));
   }
 }
 

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -145,7 +145,7 @@ export function modularScenarioFocus(event) {
     
     // update field outlines
     if (previousInput.id.startsWith('existing')) {
-      updateRight(previouscustomfield.id);
+      updateModular(previouscustomfield.id);
     } else {
       updateScenarioFieldOutlineAndTooltip(previousInput.id);
     }
@@ -538,6 +538,12 @@ export function updateRight(fieldId) {
 export function updateFocused(fieldId) {
   let field = document.getElementById(fieldId);
   field.style.outline = "1px solid blue";
+  field.title = '';
+}
+
+export function updateModular(fieldId) {
+  let field = document.getElementById(fieldId);
+  field.style.outline = "1px solid cyan";
   field.title = '';
 }
 

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -65,9 +65,11 @@ export var multiFieldChange = function (vscodeApi) { return  function (event) {
   vscodeApi.postMessage({ command: "savemultivalue", text: textString });
 
   // update scenario in currentInput
-  let element = field.getAttribute('name');
-  let multiregex = new RegExp('-' + element + '_[^-]*(-|$)');
-  let newValue = currentInput.value.replace(multiregex, '-' + element + '_' + value + '$1');
+  const parent = field.getAttribute('parent');
+  const element = field.getAttribute('name');
+  const fullName = parent + ':' + element;
+  let multiregex = new RegExp('-' + fullName + '_[^-]*(-|$)');
+  let newValue = currentInput.value.replace(multiregex, '-' + fullName + '_' + value + '$1');
   updateModularValue(currentInput.id, newValue);
 
   // trigger 'change' event to save and check content
@@ -320,7 +322,10 @@ export function updateTiles(content) {
     
     let tiles = document.querySelectorAll(".modulartile");
     for (const tile of tiles) {
-      let regex = new RegExp('-' + tile.id + '([-_]|$)');
+      let element = tile.getAttribute('name');
+      let parent = tile.getAttribute('parent');
+      let fullName = parent + ':' + element;
+      let regex = new RegExp('-' + fullName + '([-_]|$)');
       // if (currentElements.includes(tile.id)) {
       if (content.match(regex)) {
         setPrimary(tile.id);

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -67,7 +67,8 @@ export var multiFieldChange = function (vscodeApi) { return  function (event) {
   // update scenario in currentInput
   let element = field.id.replace('multifield','');
   let multiregex = new RegExp('-' + element + '_[^-]*(-|$)');
-  currentInput.value = currentInput.value.replace(multiregex, '-' + element + '_' + value + '$1');
+  let newValue = currentInput.value.replace(multiregex, '-' + element + '_' + value + '$1');
+  updateModularValue(currentInput.id, newValue);
 
   // trigger 'change' event to save and check content
   currentInput.dispatchEvent(new Event('change')); 
@@ -103,7 +104,8 @@ export var changePackages = function (vscodeApi) { return  function (event) {
     scenarioField.dispatchEvent(new Event('click'));
 
     // update scenario field with new nofPackages
-    scenarioField.value = scenarioField.value.replace(/-multi_\d-/g,"-multi_" + nofPackages + "-");
+    let newValue = scenarioField.value.replace(/-multi_\d-/g,"-multi_" + nofPackages + "-");
+    updateModularValue(scenarioField.id, newValue);
 
     // trigger 'change' event to save and check content
     scenarioField.dispatchEvent(new Event('change')); 
@@ -184,6 +186,20 @@ export function lowestUnusedDigitOr1() {
   return (lowestUnused === 0) ? 1 : lowestUnused;
 }
 
+function updateModularValue(fieldId, newValue) {
+  let field = document.getElementById(fieldId);
+  let curValue = field.value;
+
+  // update modular scenario field
+  field.value = newValue;
+
+  // update custom name if necessary
+  let custom = document.getElementById(field.id.replace('scenario','scenariocustom'));
+  if (isEmpty(custom.value) || (custom.value === curValue) ) {
+    custom.value = newValue;
+  }
+}
+
 export function setPrimary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
   const base = 'm-multi_' + getNofPackages(currentInput.id) ;
@@ -221,7 +237,11 @@ export function setPrimary(fieldId,vscodeApi) {
   let check = currentInput.value.match(regex);
   let addstring = field.id + (multifield.length > 0 ? '_' + multifield[0].value : '');
   if (!check) {
-    currentInput.value = currentInput.value + (isEmpty(currentInput.value) ? (base + '-') : '-') + addstring;
+    let curValue = currentInput.value;
+    let newValue = currentInput.value + (isEmpty(curValue) ? (base + '-') : '-') + addstring;
+
+    // update value
+    updateModularValue(currentInput.id, newValue);
 
     // trigger 'change' event to save and check content
     currentInput.dispatchEvent(new Event('change'));
@@ -258,10 +278,12 @@ export function setSecondary(fieldId,vscodeApi) {
   let multiregex = new RegExp('-' + field.id + '_[^-]*(-|$)');
 
   // replace if multi, else replace if not multi
-  let newValue = currentInput.value.replace(multiregex, '$1').replace(nonmultiregex, '$1');
+  let curValue = currentInput.value;
+  let tempNewValue = curValue.replace(multiregex, '$1').replace(nonmultiregex, '$1');
 
-  // remove base if all tiles deselected
-  currentInput.value = (newValue === base) ? '' : newValue;
+  // update field
+  let newValue = (tempNewValue === base) ? '' : tempNewValue;
+  updateModularValue(currentInput.id, newValue);
 
   // if updated: trigger 'change' event to save and check content
   if (currentInput.value !== oldValue) {

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -209,6 +209,7 @@ export function setPrimary(fieldId,vscodeApi) {
   const base = 'm-multi_' + getNofPackages(currentInput.id);
   const parent = field.getAttribute('parent');
   const element = field.getAttribute('name');
+  const fullName = parent + ':' + element;
 
   // change appearance
   field.setAttribute('appearance','primary');
@@ -219,7 +220,7 @@ export function setPrimary(fieldId,vscodeApi) {
   if (multifield.length > 0) {
     
     // extract current value from scenario field (if present)
-    let multiregex = new RegExp('-' + element + '_([^-]*)(-|$)');
+    let multiregex = new RegExp('-' + fullName + '_([^-]*)(-|$)');
     let matchMultiInScenario = currentInput.value.match(multiregex);
     if (matchMultiInScenario) {
       multifield[0].value = matchMultiInScenario[1];
@@ -239,7 +240,6 @@ export function setPrimary(fieldId,vscodeApi) {
 
   // add tile content to last selected scenario field
   // let currentElements = currentInput.value.split('-');
-  let fullName = parent + ':' + element;
   let regex = new RegExp('-' + fullName + '([-_]|$)',"g");
   let check = currentInput.value.match(regex);
   let addstring = fullName + (multifield.length > 0 ? '_' + multifield[0].value : '');
@@ -260,6 +260,7 @@ export function setSecondary(fieldId,vscodeApi) {
   const base = 'm-multi_' + getNofPackages(currentInput.id);
   const parent = field.getAttribute('parent');
   const element = field.getAttribute('name');
+  const fullName = parent + ':' + element;
 
   // change appearance
   field.setAttribute('appearance','secondary');
@@ -282,7 +283,6 @@ export function setSecondary(fieldId,vscodeApi) {
   }
 
   // remove tile content from last selected scenario field
-  let fullName = parent + ':' + element;
   let oldValue = currentInput.value;
   let nonmultiregex = new RegExp('-' + fullName + '(-|$)');
   let multiregex = new RegExp('-' + fullName + '_[^-]*(-|$)');

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -13,7 +13,11 @@ export function addScenarioEventListeners(vscodeApi) {
   for (const field of document.querySelectorAll(".scenariofield")) {
     field.addEventListener("keyup", scenarioFieldChange(vscodeApi));
     field.addEventListener("change", scenarioFieldChange(vscodeApi));
-    field.addEventListener('click',modularScenarioFocus);
+  }
+
+  // scenario custom fields
+  for (const field of document.querySelectorAll(".scenariocustomfield")) {
+    field.addEventListener('focus',modularScenarioFocus);
   }
 
   // modular checkbox
@@ -115,7 +119,8 @@ export var changePackages = function (vscodeApi) { return  function (event) {
 export function modularScenarioFocus(event) {
     // track last selected scenario field
     // from https://stackoverflow.com/a/68176703/1716283
-    const field = event.target;
+    const customfield = event.target;
+    const field = document.getElementById(customfield.id.replace('scenariocustom','scenario'));
 
     if (field.id !== currentInput.id && isModular()) {
       // update currentInput
@@ -390,17 +395,18 @@ export function updateScenarioFieldOutlineAndTooltip(fieldId) {
     let field = document.getElementById(fieldId);
   
     if (field.classList[0] === 'scenariofield') {
+        let customfield = document.getElementById(field.id.replace('scenario','scenariocustom'));
         // check for duplicate scenarios
         if (isScenarioDuplicate(field.id) && !isEmpty(field.value)) {
           isCorrect = false;
-          updateScenarioFieldDuplicate(field.id);
+          updateScenarioFieldDuplicate(customfield.id);
         } else if (isModular() && !checkModularScenario(field.id)) {
-          updateScenarioFieldWrongModularScenario(field.id);
+          updateScenarioFieldWrongModularScenario(customfield.id);
           isCorrect = false;
         } else if (field.id === currentInput.id && isModular()) { 
-          updateScenarioFieldFocused(field.id);
+          updateScenarioFieldFocused(customfield.id);
         } else {
-          updateScenarioFieldRight(field.id);
+          updateScenarioFieldRight(customfield.id);
         }
     }
     

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -438,20 +438,16 @@ export function updateScenarioFieldOutlineAndTooltip(fieldId) {
   
     if (field.classList[0] === 'scenariofield') {
         let customfields = document.querySelectorAll('#' + field.id.replace('scenario','scenariocustom'));
-        let customfield = (customfields.length > 0) ? customfields[0] : field;
-
-        // check if scenario is correct
-        // if (isScenarioDuplicate(field.id) && !isEmpty(field.value)) {
-        //   isCorrect = false;
-        //   updateWrong(customfield.id,'Scenario is duplicate of other (existing) scenario');
-        // } else 
-        if (isModular() && !checkModularScenario(field.id)) {
-          updateWrong(customfield.id,'One or more modular element fields are invalid. select scenario to see more details.');
-          isCorrect = false;
-         
-        // check if custom name is correct
-        } else if (isModular()) {
-          if (!checkCustomName(customfield.id)) {
+        let customfield = (customfields.length > 0) ? customfields[0] : field;         
+        
+        if (isModular()) {
+          // check if modular element fields are correct
+          if (!checkModularScenario(field.id)) {
+            updateWrong(customfield.id,'One or more modular element fields are invalid. select scenario to see more details.');
+            isCorrect = false;
+          
+          // check if custom name is correct
+          } else if (!checkCustomName(customfield.id)) {
             updateWrong(customfield.id,'Allowed: A-Z, a-z, 0-9, -, _ (no spaces)');
             isCorrect = false;
           } else if (isCustomNameDuplicate(customfield.id) && !isEmpty(customfield.value)) { 
@@ -473,8 +469,15 @@ export function updateScenarioFieldOutlineAndTooltip(fieldId) {
             updateRight(customfield.id);
           }
 
+        // else if not modular
         } else {
-          updateRight(customfield.id);
+           // check if scenario is not duplicate
+          if (isScenarioDuplicate(field.id) && !isEmpty(field.value)) {
+            isCorrect = false;
+            updateWrong(customfield.id,'Scenario is duplicate of other (existing) scenario');
+          } else {
+            updateRight(customfield.id);
+          }
         }
     }
     
@@ -513,7 +516,7 @@ export function isScenarioDuplicate(fieldId) {
   var isDuplicate = false;
   let field = document.getElementById(fieldId);
   
-  // check other new scenarios
+  // compare other new scenarios 
   var scenarioFields = document.querySelectorAll(".scenariofield");
   for (const sf of scenarioFields) {
     if (sf.id !== field.id && sf.value === field.value && !isEmpty(sf.value)) {
@@ -522,11 +525,11 @@ export function isScenarioDuplicate(fieldId) {
       break;
     }
   }
-
-  // check existing scenarios (if present)
+  
+  // compare existing scenario names (if present)
   if (!isDuplicate ) {
     var actualValue = getNewScenarioValue(field.value);
-    var existingScenarios = document.querySelectorAll(".existingscenariofield");
+    var existingScenarios = document.querySelectorAll(".existingscenariocustomfield");
     for (const es of existingScenarios) {
       if (actualValue === es.value ) {
         // if scenario equal to existing scenario: duplicate

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -556,7 +556,7 @@ export function isCustomNameDuplicate(fieldId) {
   // check existing scenarios (if present)
   if (!isDuplicate ) {
     var actualValue = getNewScenarioValue(field.value);
-    var existingScenarios = document.querySelectorAll(".existingscenariofield");
+    var existingScenarios = document.querySelectorAll(".existingscenariocustomfield");
     for (const es of existingScenarios) {
       if (actualValue === es.value ) {
         // if scenario equal to existing scenario: duplicate

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -137,7 +137,7 @@ export function modularScenarioFocus(event) {
   const customfield = event.target;
   const field = document.getElementById(customfield.id.replace('scenariocustom','scenario'));
 
-  if (field.id !== currentInput.id && isModular() && (isModularScenario(field.value) || !field.id.startsWith('existing'))) {
+  if (field.id !== currentInput.id && isModular() && (isModularScenario(field.value) || field.classList[0] === 'scenariofield')) {
     // update currentInput
     let previousInput = currentInput;
     const previouscustomfield = document.getElementById(previousInput.id.replace('scenario','scenariocustom'));

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -65,7 +65,7 @@ export var multiFieldChange = function (vscodeApi) { return  function (event) {
   vscodeApi.postMessage({ command: "savemultivalue", text: textString });
 
   // update scenario in currentInput
-  let element = field.id.replace('multifield','');
+  let element = field.getAttribute('name');
   let multiregex = new RegExp('-' + element + '_[^-]*(-|$)');
   let newValue = currentInput.value.replace(multiregex, '-' + element + '_' + value + '$1');
   updateModularValue(currentInput.id, newValue);
@@ -194,26 +194,30 @@ function updateModularValue(fieldId, newValue) {
   field.value = newValue;
 
   // update custom name if necessary
+  let curCleanValue = curValue.replace(/\:/g,'');
+  let newCleanValue = newValue.replace(/\:/g,'');
   let custom = document.getElementById(field.id.replace('scenario','scenariocustom'));
-  if (isEmpty(custom.value) || (custom.value === curValue) ) {
-    custom.value = newValue;
+  if (isEmpty(custom.value) || (custom.value === curCleanValue) ) {
+    custom.value = newCleanValue;
   }
 }
 
 export function setPrimary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
-  const base = 'm-multi_' + getNofPackages(currentInput.id) ;
+  const base = 'm-multi_' + getNofPackages(currentInput.id);
+  const parent = field.getAttribute('parent');
+  const element = field.getAttribute('name');
 
   // change appearance
   field.setAttribute('appearance','primary');
 
   // set multifield if present (and not already set)
-  let multifield = document.querySelectorAll("#multifield" + fieldId);
+  let multifield = document.querySelectorAll("#multifield" + parent + element);
 
   if (multifield.length > 0) {
     
     // extract current value from scenario field (if present)
-    let multiregex = new RegExp('-' + field.id + '_([^-]*)(-|$)');
+    let multiregex = new RegExp('-' + element + '_([^-]*)(-|$)');
     let matchMultiInScenario = currentInput.value.match(multiregex);
     if (matchMultiInScenario) {
       multifield[0].value = matchMultiInScenario[1];
@@ -233,9 +237,10 @@ export function setPrimary(fieldId,vscodeApi) {
 
   // add tile content to last selected scenario field
   // let currentElements = currentInput.value.split('-');
-  let regex = new RegExp('-' + field.id + '([-_]|$)',"g");
+  let fullName = parent + ':' + element;
+  let regex = new RegExp('-' + fullName + '([-_]|$)',"g");
   let check = currentInput.value.match(regex);
-  let addstring = field.id + (multifield.length > 0 ? '_' + multifield[0].value : '');
+  let addstring = fullName + (multifield.length > 0 ? '_' + multifield[0].value : '');
   if (!check) {
     let curValue = currentInput.value;
     let newValue = currentInput.value + (isEmpty(curValue) ? (base + '-') : '-') + addstring;
@@ -250,13 +255,15 @@ export function setPrimary(fieldId,vscodeApi) {
 
 export function setSecondary(fieldId,vscodeApi) {
   let field = document.getElementById(fieldId);
-  const base = 'm-multi_' + getNofPackages(currentInput.id) ;
+  const base = 'm-multi_' + getNofPackages(currentInput.id);
+  const parent = field.getAttribute('parent');
+  const element = field.getAttribute('name');
 
   // change appearance
   field.setAttribute('appearance','secondary');
 
   // clear multifield if present
-  let multifield = document.querySelectorAll("#multifield" + fieldId);
+  let multifield = document.querySelectorAll("#multifield" + parent + element);
   if (multifield.length > 0) {
 
     //clear multi value
@@ -273,9 +280,10 @@ export function setSecondary(fieldId,vscodeApi) {
   }
 
   // remove tile content from last selected scenario field
+  let fullName = parent + ':' + element;
   let oldValue = currentInput.value;
-  let nonmultiregex = new RegExp('-' + field.id + '(-|$)');
-  let multiregex = new RegExp('-' + field.id + '_[^-]*(-|$)');
+  let nonmultiregex = new RegExp('-' + fullName + '(-|$)');
+  let multiregex = new RegExp('-' + fullName + '_[^-]*(-|$)');
 
   // replace if multi, else replace if not multi
   let curValue = currentInput.value;

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -17,6 +17,8 @@ export function addScenarioEventListeners(vscodeApi) {
 
   // scenario custom fields
   for (const field of document.querySelectorAll(".scenariocustomfield")) {
+    field.addEventListener("keyup", scenarioFieldChange(vscodeApi));
+    field.addEventListener("change", scenarioFieldChange(vscodeApi));
     field.addEventListener('focus',modularScenarioFocus);
   }
 

--- a/scripts/general/scenariofunctions.js
+++ b/scripts/general/scenariofunctions.js
@@ -437,7 +437,8 @@ export function updateScenarioFieldOutlineAndTooltip(fieldId) {
     let field = document.getElementById(fieldId);
   
     if (field.classList[0] === 'scenariofield') {
-        let customfield = document.getElementById(field.id.replace('scenario','scenariocustom'));
+        let customfields = document.querySelectorAll('#' + field.id.replace('scenario','scenariocustom'));
+        let customfield = (customfields.length > 0) ? customfields[0] : field;
 
         // check if scenario is correct
         // if (isScenarioDuplicate(field.id) && !isEmpty(field.value)) {
@@ -449,24 +450,29 @@ export function updateScenarioFieldOutlineAndTooltip(fieldId) {
           isCorrect = false;
          
         // check if custom name is correct
-        } else if (!checkCustomName(customfield.id)) {
-          updateWrong(customfield.id,'Allowed: A-Z, a-z, 0-9, -, _ (no spaces)');
-          isCorrect = false;
-        } else if (isCustomNameDuplicate(customfield.id) && !isEmpty(customfield.value)) { 
-          updateWrong(customfield.id,'Name is duplicate of other (existing) scenario');
-          isCorrect = false;
+        } else if (isModular()) {
+          if (!checkCustomName(customfield.id)) {
+            updateWrong(customfield.id,'Allowed: A-Z, a-z, 0-9, -, _ (no spaces)');
+            isCorrect = false;
+          } else if (isCustomNameDuplicate(customfield.id) && !isEmpty(customfield.value)) { 
+            updateWrong(customfield.id,'Name is duplicate of other (existing) scenario');
+            isCorrect = false;
 
-        // check if combination is correct
-        } else if (isEmpty(field.value) && !isEmpty(customfield.value)) {
-          updateWrong(customfield.id,'No tiles selected');
-          isCorrect = false;
-        } else if (!isEmpty(field.value) && isEmpty(customfield.value)) {
-          updateWrong(customfield.id,'Must specify name if tiles selected');
-          isCorrect = false;
+          // check if combination is correct
+          } else if (isEmpty(field.value) && !isEmpty(customfield.value)) {
+            updateWrong(customfield.id,'No tiles selected');
+            isCorrect = false;
+          } else if (!isEmpty(field.value) && isEmpty(customfield.value)) {
+            updateWrong(customfield.id,'Must specify name if tiles selected');
+            isCorrect = false;
 
-        // check focused or correct
-        } else if (field.id === currentInput.id && isModular()) { 
-          updateFocused(customfield.id);
+          // check focused or correct
+          } else if (field.id === currentInput.id) { 
+            updateFocused(customfield.id);
+          } else {
+            updateRight(customfield.id);
+          }
+
         } else {
           updateRight(customfield.id);
         }

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -33,7 +33,8 @@ export class CreateIntegrationHtmlObject {
     private _stepTypeOptions: string[],
     private _stepTypes: string[],
     private _stepMethodOptions: string[],
-    private _stepMethods: string[]
+    private _stepMethods: string[],
+    private _scenarioCustomFields: string[]
     ) { }
 
   // METHODS
@@ -53,7 +54,8 @@ export class CreateIntegrationHtmlObject {
       +this._fieldValues[nofScenariosIndex], 
       nofScenariosIndex,
       this._multiFieldValues,
-      this._nofPackages
+      this._nofPackages,
+      this._scenarioCustomFields
     );
 
     // define panel HTML

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -94,12 +94,12 @@ export class CreateIntegrationHtmlObject {
             
             <section  class="rowsingle">
               ${this._ifCreate(this._getStepsGrid())}
+              ${this._ifUpdate(this._getExistingScenariosGrid())}
             </section>
           </section>
 
           <section class="rowsingle">
             ${scenarioGrid.getHtml()}
-            ${this._ifUpdate(this._getExistingScenariosGrid())}
           </section>
         </section>
 

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getUri, valueString, checkedString, hiddenString, disabledString, dropdownOptions, arrayFrom1, toBoolean } from "../utilities/functions";
+import { getUri, valueString, checkedString, hiddenString, disabledString, dropdownOptions, arrayFrom1, toBoolean, isModular } from "../utilities/functions";
 import { ScenarioGridObject } from "../utilities/ScenarioGridObject";
 
 // fixed fields indices
@@ -268,6 +268,8 @@ export class CreateIntegrationHtmlObject {
     let html: string = ``;
 
     for (let index = 0; index < this._existingScenarioFieldValues.length; index++) {
+      const modularOutline = 'style="outline:1px solid cyan"';
+      let outlineString = isModular(this._existingScenarioFieldValues[index]) ? modularOutline : '';
       let checked = '';
       let disabledReadonly = 'disabled';
       if (this._existingScenarioCheckboxValues[index] === true) {
@@ -279,7 +281,7 @@ export class CreateIntegrationHtmlObject {
         <section class="component-example">
           <vscode-checkbox id="runexistingscenario${index}" class="existingscenariocheckbox" index="${index}" ${checked}></vscode-checkbox>
           <vscode-text-field id="existingscenario${index}" class="existingscenariofield" value="${this._existingScenarioFieldValues[index]}" hidden></vscode-text-field>
-          <vscode-text-field id="existingscenariocustom${index}" class="existingscenariocustomfield" value="${this._existingScenarioCustomFields[index]}" ${disabledReadonly}></vscode-text-field>
+          <vscode-text-field id="existingscenariocustom${index}" class="existingscenariocustomfield" value="${this._existingScenarioCustomFields[index]}" ${outlineString} ${disabledReadonly}></vscode-text-field>
         </section>
       `;
     }

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -278,7 +278,7 @@ export class CreateIntegrationHtmlObject {
       html += /*html*/`
         <section class="component-example">
           <vscode-checkbox id="runexistingscenario${index}" class="existingscenariocheckbox" index="${index}" ${checked}></vscode-checkbox>
-          <vscode-text-field id="existingscenario${index}" class="existingscenariofield" value="${this._existingScenarioFieldValues[index]}" ${disabledReadonly}></vscode-text-field>
+          <vscode-text-field id="existingscenario${index}" class="existingscenariofield" value="${this._existingScenarioFieldValues[index]}" hidden></vscode-text-field>
           <vscode-text-field id="existingscenariocustom${index}" class="existingscenariocustomfield" value="${this._existingScenarioCustomFields[index]}" ${disabledReadonly}></vscode-text-field>
         </section>
       `;

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -34,7 +34,8 @@ export class CreateIntegrationHtmlObject {
     private _stepTypes: string[],
     private _stepMethodOptions: string[],
     private _stepMethods: string[],
-    private _scenarioCustomFields: string[]
+    private _scenarioCustomFields: string[],
+    private _existingScenarioCustomFields: string[]
     ) { }
 
   // METHODS
@@ -273,6 +274,7 @@ export class CreateIntegrationHtmlObject {
         <section class="component-example">
           <vscode-checkbox id="runexistingscenario${index}" class="existingscenariocheckbox" index="${index}" ${checked}></vscode-checkbox>
           <vscode-text-field id="existingscenario${index}" class="existingscenariofield" value="${this._existingScenarioFieldValues[index]}" ${disabledReadonly}></vscode-text-field>
+          <vscode-text-field id="existingscenariocustom${index}" class="existingscenariocustomfield" value="${this._existingScenarioCustomFields[index]}" ${disabledReadonly}></vscode-text-field>
         </section>
       `;
     }

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -160,12 +160,17 @@ export class CreateIntegrationHtmlObject {
         </section>
       </section>
 
-      <section class="component-example">
-        <p>SiS CarrierCode</p>
-        <vscode-text-field id="carriercode" class="field" index="${carrierCodeIndex}" ${valueString(this._fieldValues[carrierCodeIndex])} placeholder="DPD"></vscode-text-field>
-      </section>`;
+      ${this._ifCreate(this._getCarrierCodeField())}`;
 
     return carrierFolderStructureGrid;
+  }
+
+  private _getCarrierCodeField() : string {
+    return /*html*/ `
+    <section class="component-example">
+      <p>SiS CarrierCode</p>
+      <vscode-text-field id="carriercode" class="field" index="${carrierCodeIndex}" ${valueString(this._fieldValues[carrierCodeIndex])} placeholder="DPD"></vscode-text-field>
+    </section>`;
   }
 
   private _getStepsGrid(): string {

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -575,6 +575,8 @@ export class CreateIntegrationPanel {
 
     // crop scenarios array
     this._scenarioFieldValues = this._scenarioFieldValues.slice(0, +this._fieldValues[nofScenariosIndex]);
+    this._scenarioCustomFields = this._scenarioCustomFields.slice(0, +this._fieldValues[nofScenariosIndex]);
+    this._nofPackages = this._nofPackages.slice(0, +this._fieldValues[nofScenariosIndex]);
   }
 
   private async _getWebviewContent(webview: vscode.Webview, extensionUri: vscode.Uri): Promise<string> {

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -602,8 +602,7 @@ export class CreateIntegrationPanel {
     this._cropFlexFields();
 
     // show only available scenarios which are not already in the existing scenarios
-    let reducedAvailableScenarios = this._availableScenarios.filter(el => !this._existingScenarioFieldValues.includes(this._getNewScenarioValue(el)));
-
+    let reducedAvailableScenarios = this._availableScenarios.filter(el => !this._existingScenarioCustomFields.includes(this._getNewScenarioValue(el)));
 
     // Create panel Html object and retrieve html
     let createIntegrationHtmlObject: CreateIntegrationHtmlObject = new CreateIntegrationHtmlObject(

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -384,7 +384,19 @@ export class CreateIntegrationPanel {
   }
 
   private _getNewScenarios() : string[] {
-    return this._scenarioFieldValues.map( el => this._getNewScenarioValue(el)).filter(el => !isEmpty(el)).sort();
+    let newScenarios: string[] = [];
+    // if modular: combine with custom names
+    if (this._modularValue) {
+      for (let index = 0; index < this._scenarioFieldValues.length; index++) {
+        if (!isEmpty(this._scenarioFieldValues[index])) {
+          newScenarios[index] = this._scenarioFieldValues[index] + '|' + this._scenarioCustomFields[index];
+        }
+      }
+    } else {
+      newScenarios =  this._scenarioFieldValues.map( el => this._getNewScenarioValue(el));
+    }
+
+    return newScenarios.filter(el => !isEmpty(el)).sort();
   }
 
   private _getScenariosString(): string {

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -37,6 +37,7 @@ export class CreateIntegrationPanel {
   private _stepTypes: string[] = [];
   private _stepMethodOptions: string[] = [];
   private _stepMethods: string[] = [];
+  private _scenarioCustomFields: string[] = [];
 
   // constructor
   private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, nofSteps: number, context: vscode.ExtensionContext) {
@@ -187,6 +188,9 @@ export class CreateIntegrationPanel {
                 break;
               case 'scenariofield':
                 this._scenarioFieldValues[index] = value;
+                break;
+              case 'scenariocustomfield':
+                this._scenarioCustomFields[index] = value;
                 break;
               case 'existingscenariocheckbox':
                 this._existingScenarioCheckboxValues[index] = toBoolean(value);
@@ -582,7 +586,8 @@ export class CreateIntegrationPanel {
       this._stepTypeOptions,
       this._stepTypes,
       this._stepMethodOptions,
-      this._stepMethods
+      this._stepMethods,
+      this._scenarioCustomFields
     );
 
     let html =  createIntegrationHtmlObject.getHtml();

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -302,6 +302,7 @@ export class CreateIntegrationPanel {
       // refresh window
       this._fieldValues[nofScenariosIndex] = "1";
       this._scenarioFieldValues = [];
+      this._scenarioCustomFields = [];
       this._checkIntegrationExists(extensionUri);
   }
 

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getUri, getWorkspaceFile, getWorkspaceFiles, startScript, cleanPath, parentPath, toBoolean, isEmptyStringArray, isEmpty, getAvailableIntegrations, getModularElements, getModularElementsWithParents, getAvailableScenarios, getFromScript} from "../utilities/functions";
+import { getUri, getWorkspaceFile, getWorkspaceFiles, startScript, cleanPath, parentPath, toBoolean, isEmptyStringArray, isEmpty, getAvailableIntegrations, getModularElements, getModularElementsWithParents, getAvailableScenarios, getFromScript, isModular} from "../utilities/functions";
 import * as fs from 'fs';
 import { CreateIntegrationHtmlObject } from "./CreateIntegrationHtmlObject";
 
@@ -431,9 +431,12 @@ export class CreateIntegrationPanel {
     // add existing scenarios (if 'update')
     if (this._createUpdateValue === 'update') {
       for (let index = 0; index < this._existingScenarioFieldValues.length; index++) {
+        var structure = this._existingScenarioFieldValues[index];
+        var customName = this._existingScenarioCustomFields[index];
+ 
         scenarioObjectArray.push( {
           execute: this._existingScenarioCheckboxValues[index],
-          name: this._existingScenarioFieldValues[index]
+          name: structure + (isModular(structure) ? ('|' + customName  ) : '' )
         });
       }
     }

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -36,7 +36,8 @@ export class CreatePostmanCollectionHtmlObject {
     private _multiFieldValues: {[details: string] : string;},
     private _nofPackages: string[],
     private _pmcObjects : {parent:string, file:string, path:string}[],
-    private _showLoad: boolean
+    private _showLoad: boolean,
+    private _scenarioCustomFields: string[]
   ) { }
 
   // METHODS
@@ -56,7 +57,8 @@ export class CreatePostmanCollectionHtmlObject {
       +this._fieldValues[nofScenariosIndex], 
       nofScenariosIndex,
       this._multiFieldValues,
-      this._nofPackages
+      this._nofPackages,
+      this._scenarioCustomFields
     );
 
     // define panel HTML

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -200,6 +200,8 @@ export class CreatePostmanCollectionPanel {
                   case nofScenariosIndex:
                     // crop scenarios array
                     this._scenarioFieldValues = this._scenarioFieldValues.slice(0, +this._fieldValues[nofScenariosIndex]);
+                    this._scenarioCustomFields = this._scenarioCustomFields.slice(0, +this._fieldValues[nofScenariosIndex]);
+                    this._nofPackages = this._nofPackages.slice(0, +this._fieldValues[nofScenariosIndex]);
                     this._updateWebview(extensionUri);
                     break;
                 }

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -329,14 +329,16 @@ export class CreatePostmanCollectionPanel {
       }
   
       // update scenarios
-      this._modularValue = isModular(pmc.item[0].name);
+      this._modularValue = isModular(pmc.item[0].structure);
       this._fieldValues[nofScenariosIndex] = pmc.item.length;
       this._scenarioFieldValues = [];
+      this._scenarioCustomFields = [];
       this._nofPackages = [];
       for (let index = 0; index < pmc.item.length; index++) {
   
         if (this._modularValue) {
-          this._scenarioFieldValues[index] = pmc.item[index].name;
+          this._scenarioFieldValues[index] = pmc.item[index].structure;
+          this._scenarioCustomFields[index] = pmc.item[index].name;
   
           // extract nofPackages
           var nofPackages = pmc.item[index].name.match('(?<=multi_)\\d+');

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -425,18 +425,8 @@ export class CreatePostmanCollectionPanel {
     }'`;
 
     // scenarios string
-    let newScenariosString : string = '';
-    let newScenarios = this._getNewScenarios();
-    for (const scenario of newScenarios) {
-      newScenariosString += `\n '${scenario}'`;
-
-      // add comma
-      if (scenario !== newScenarios[newScenarios.length-1]) {
-        newScenariosString += ',';
-      }
-    }
-
-    let defScenariosString = (this._independent) ? `$Scenarios = @( ${newScenariosString} )` : '';
+    let newScenariosString =  this._getNewScenarios().join(`",\n"`);
+    let defScenariosString = (this._independent) ? `$Scenarios = @( \n "${newScenariosString}" \n)` : '';
 
     let applyScenariosString = (this._independent) ? '-Scenarios $Scenarios' : '';
     let loadFunctions = `. "..\\..\\scenario-templates\\scripts\\functions.ps1"`;
@@ -479,7 +469,19 @@ export class CreatePostmanCollectionPanel {
   }
 
   private _getNewScenarios() : string[] {
-    return this._scenarioFieldValues.map( el => this._getNewScenarioValue(el)).filter(el => !isEmpty(el)).sort();
+    let newScenarios: string[] = [];
+    // if modular: combine with custom names
+    if (this._modularValue) {
+      for (let index = 0; index < this._scenarioFieldValues.length; index++) {
+        if (!isEmpty(this._scenarioFieldValues[index])) {
+          newScenarios[index] = this._scenarioFieldValues[index] + '|' + this._scenarioCustomFields[index];
+        }
+      }
+    } else {
+      newScenarios =  this._scenarioFieldValues.map( el => this._getNewScenarioValue(el));
+    }
+
+    return newScenarios.filter(el => !isEmpty(el)).sort();
   }
 
   private _getIntegrationName(): string {

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -40,6 +40,7 @@ export class CreatePostmanCollectionPanel {
   private _pmcObjects : {parent:string, file:string, path:string}[] = [];
 
   private _showLoad : boolean = false;
+  private _scenarioCustomFields: string[] = [];
   private _codeCompanies: {
     company: string,
     codecompany: string
@@ -264,6 +265,10 @@ export class CreatePostmanCollectionPanel {
 
               case 'scenariofield':
                 this._scenarioFieldValues[index] = value;
+                break;
+              
+              case 'scenariocustomfield':
+                this._scenarioCustomFields[index] = value;
                 break;
 
               case 'showload':
@@ -630,7 +635,8 @@ export class CreatePostmanCollectionPanel {
       this._multiFieldValues,
       this._nofPackages,
       this._pmcObjects,
-      this._showLoad
+      this._showLoad,
+      this._scenarioCustomFields
     );
 
     let html =  createPostmanCollectionHtmlObject.getHtml();

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -34,9 +34,8 @@ export class CreatePostmanCollectionPanel {
   private _modularValue: boolean = false;
   private _multiFieldValues: {[details: string] : string;} = {};
   private _nofPackages: string[] = [];
-  private _integrationObjects: {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}[] = [];
-  private _emptyIntegrationObject : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]} = {path: '', carrier: '', api: '', module: '', carriercode: '', modular: false, scenarios: [], validscenarios:[]};
-  
+  private _integrationObjects:      {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios: {name:string, structure:string}[]}[] = [];
+
   private _pmcObjects : {parent:string, file:string, path:string}[] = [];
 
   private _showLoad : boolean = false;
@@ -286,7 +285,7 @@ export class CreatePostmanCollectionPanel {
     );
   }
 
-  private _getIntegrationObject() : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]} {
+  private _getIntegrationObject() : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:{name:string, structure:string}[]} {
     return this._integrationObjects.filter(el => this._fieldValues[carrierIndex] === el.carrier && this._fieldValues[apiIndex] === el.api  && this._fieldValues[moduleIndex] === el.module)[0];
   }
 

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -15,7 +15,8 @@ export class ScenarioGridObject {
         private _nofScenarios: number,
         private _nofScenariosIndex: number,
         private _multiFieldValues: {[details: string] : string;},
-        private _nofPackages: string[]
+        private _nofPackages: string[],
+        private _scenarioCustomFields: string[]
     ) { }
 
     public getHtml(): string {
@@ -106,7 +107,7 @@ export class ScenarioGridObject {
             <vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" readonly></vscode-text-field>
         </section>
         <section class="component-example">
-            <vscode-text-field id="scenariocustom${index}" index="${index}" ${valueString('')} class="scenariocustomfield" placeholder="${(index + 1) + nth(index + 1)} scenario name..."></vscode-text-field>
+            <vscode-text-field id="scenariocustom${index}" index="${index}" ${valueString(this._scenarioCustomFields[index])} class="scenariocustomfield" placeholder="${(index + 1) + nth(index + 1)} scenario name..."></vscode-text-field>
         </section>`;
     }
 

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -103,7 +103,10 @@ export class ScenarioGridObject {
     private _getScenarioInputField(index:number) : string {
         return /*html*/ `
         <section class="component-example">
-            <vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" placeholder="${(index + 1) + nth(index + 1)} scenario name..." readonly></vscode-text-field>
+            <vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" readonly></vscode-text-field>
+        </section>
+        <section class="component-example">
+            <vscode-text-field id="scenariocustom${index}" index="${index}" ${valueString('')} class="scenariocustomfield" placeholder="${(index + 1) + nth(index + 1)} scenario name..."></vscode-text-field>
         </section>`;
     }
 

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -104,7 +104,7 @@ export class ScenarioGridObject {
     private _getScenarioInputField(index:number) : string {
         return /*html*/ `
         <section class="component-example">
-            <vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" readonly></vscode-text-field>
+            <vscode-text-field id="scenario${index}" index="${index}" ${valueString(this._scenarioFieldValues[index])} class="scenariofield" hidden></vscode-text-field>
         </section>
         <section class="component-example">
             <vscode-text-field id="scenariocustom${index}" index="${index}" ${valueString(this._scenarioCustomFields[index])} class="scenariocustomfield" placeholder="${(index + 1) + nth(index + 1)} scenario name..."></vscode-text-field>

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -136,9 +136,9 @@ export class ScenarioGridObject {
                     // build modular tile (and add multifield, if appropriate)
                     modularTiles += /*html*/ `
                     <section class="component-example">
-                        <vscode-button id="${element}" class="modulartile" appearance="secondary">${element}</vscode-button>
+                        <vscode-button id="${this._getCleanParent(parent) + element}" name="${element}" class="modulartile" parent="${this._getCleanParent(parent)}" appearance="secondary">${element}</vscode-button>
                         ${ currentElementObject.multi ? /*html*/ `
-                            <vscode-text-field id="multifield${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>
+                            <vscode-text-field id="multifield${this._getCleanParent(parent) + element}" name="${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>
                         ` : ''}
                     </section>
                     `;

--- a/src/utilities/ScenarioGridObject.ts
+++ b/src/utilities/ScenarioGridObject.ts
@@ -138,7 +138,7 @@ export class ScenarioGridObject {
                     <section class="component-example">
                         <vscode-button id="${this._getCleanParent(parent) + element}" name="${element}" class="modulartile" parent="${this._getCleanParent(parent)}" appearance="secondary">${element}</vscode-button>
                         ${ currentElementObject.multi ? /*html*/ `
-                            <vscode-text-field id="multifield${this._getCleanParent(parent) + element}" name="${element}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>
+                            <vscode-text-field id="multifield${this._getCleanParent(parent) + element}" name="${element}" parent="${this._getCleanParent(parent)}" ${valueString(this._multiFieldValues["multifield" + element])} class="multifield" placeholder="packages..." hidden></vscode-text-field>
                         ` : ''}
                     </section>
                     `;

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -173,7 +173,7 @@ export async function getAvailableIntegrations(panel:string) : Promise<{path:str
 
 		// filter on valid scenarios
 		let availableScenarios = await getAvailableScenarios(module, false);
-		let modularElements = await getModularElements(module);
+		let modularElements = (await getModularElementsWithParents(module)).map(el => (isEmpty(el.parent) ? '' : (el.parent.replace(/[^_]*_/g,'') + ':')) + el.element);
 		let validScenarios : {name:string, structure:string}[] = scenarioNameStructures.filter(el => isScenarioValid(el.structure, availableScenarios, modularElements));
 
 		// add array element

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -105,14 +105,30 @@ export async function getPostmanCollectionFiles(): Promise<{parent:string, file:
 	return pmcObjects;
 }
 
-export async function getAvailableIntegrations(panel:string) : Promise<{path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}[]> {
+export function getScenarioAndStructure(path:string) : {name:string, structure:string} {
+	// name
+	let name = nameFromPath(path);
+
+	// structure
+	let structurePath = path + '/structure.jsonc';
+	let structureExists: boolean = fs.existsSync(structurePath);
+	let structure = structureExists ? JSON.parse(fs.readFileSync(structurePath, 'utf8')).structure : name;
+
+	// return as object
+	return {
+		name: name,
+		structure: structure
+	};
+}
+
+export async function getAvailableIntegrations(panel:string) : Promise<{path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios: {name:string, structure:string}[]}[]> {
 	// panel input: 'integration' or 'postman'
 
 	// integration script path array
 	let integrationScripts: string[] = await getWorkspaceFiles('**/carriers/*/create-*integration*.ps1');
 
 	// pre-allocate output
-	let integrationObjects : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}[] = new Array<{path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios:string[], validscenarios:string[]}>(integrationScripts.length);
+	let integrationObjects : {path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios: string[], validscenarios: {name:string, structure:string}[]}[] = new Array<{path:string, carrier:string, api:string, module:string, carriercode:string, modular: boolean, scenarios: string[], validscenarios: {name:string, structure:string}[]}>(integrationScripts.length);
 
 	// build integration array
 	let newIndex: number = 0;
@@ -144,13 +160,21 @@ export async function getAvailableIntegrations(panel:string) : Promise<{path:str
 		}
 
 		// obtain valid scenarios from scenarios folder
-		let scenarioDir = fs.readdirSync(parentPath(cleanPath(script)) + `/${api}/${module}/scenarios`);
+		let scenariosDir: string = parentPath(cleanPath(script)) + `/${api}/${module}/scenarios`;
+		let scenarioDir = fs.readdirSync(scenariosDir);
 		let integrationScenarios = scenarioDir.filter(el => !el.includes('.')).sort();
+
+		let scenarioNameStructures: {name:string, structure:string}[] = new Array<{name:string, structure:string}>(integrationScenarios.length);
+		for (let index = 0; index < scenarioNameStructures.length; index++) {
+			scenarioNameStructures[index] = getScenarioAndStructure(scenariosDir + '/' + integrationScenarios[index]);
+		}
+
+		//let scenarioStructures = scenarioDir.map((el) => fs.existsSync(scenariosDir + '/' + el + '/structure.jsonc') ? JSON.parse(fs.readFileSync(scenariosDir + '/' + el + '/structure.jsonc', 'utf8')).structure : el);
 
 		// filter on valid scenarios
 		let availableScenarios = await getAvailableScenarios(module, false);
 		let modularElements = await getModularElements(module);
-		let validScenarios : string [] = integrationScenarios.filter(el => isScenarioValid(el, availableScenarios, modularElements));
+		let validScenarios : {name:string, structure:string}[] = scenarioNameStructures.filter(el => isScenarioValid(el.structure, availableScenarios, modularElements));
 
 		// add array element
 		integrationObjects[newIndex] = {
@@ -160,7 +184,7 @@ export async function getAvailableIntegrations(panel:string) : Promise<{path:str
 			module: 	 module,
 			carriercode: getFromScript(scriptContent,'CARRIERCODE'),
 			modular: 	 modular,
-			scenarios:   integrationScenarios,
+			scenarios:   scenarioNameStructures.map(el => el.name),
 			validscenarios: validScenarios
 		};
 


### PR DESCRIPTION
## 1.5.1
- Modular scenarios
  - Now allows customised modular scenario names
  - Now allows multiple modular tiles with the same name (as long as they are in different subfolders)
  - Integration: existing scenarios
    - Now shows which existing scenarios are modular (since cannot be deduced anymore from name)
    - When existing modular scenario is checked, selecting the existing scenario name field will show which modular tiles it consists of

- fix
  - Now checks if new fixed scenario is not selected twice
  - Integration: now hides carrier code field on 'update'
- style
  - Integration: on 'update', existing scenarios are now on the left, right under the carrier details