### PR TITLE
Pmc load bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.5.2
+- Postman collection
+  - fix: now correctly loads number of packages fields from existing postman collection file
+
 ## 1.5.1
 - Modular scenarios
   - Now allows customised modular scenario names

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -343,7 +343,7 @@ export class CreatePostmanCollectionPanel {
           this._scenarioCustomFields[index] = pmc.item[index].name;
   
           // extract nofPackages
-          var nofPackages = pmc.item[index].name.match('(?<=multi_)\\d+');
+          var nofPackages = pmc.item[index].structure.match('(?<=multi_)\\d+');
           if (nofPackages) {
             this._nofPackages[index] = nofPackages[0];
           }


### PR DESCRIPTION
## 1.5.2
- Postman collection
  - fix: now correctly loads number of packages fields from existing postman collection file