### PR TITLE
Parameter feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.6.1
+- Get/set Parameters
+  - When Environment dropdown set to 'PROD', color dropdown bright red and panel background dark red
+  - On pressing 'Set Parameter' button
+    - Add environment name to saved file
+    - Update input layout and highlight, uncheck 'previous' checkbox, clear previous Get/Set responses and current values
+- Add highlight to current value fields which are unequal to new values (or previous values, if 'previous' checkbox is set)
+
 ## 1.6.0
 - Get/set Parameters
   - Added new Get/set Parameters panel, allowing mass check and change of SiS parameters, by either uploading a CSV file, or manual input.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -46,7 +46,7 @@ function main() {
 function fieldChange(event) {
   const field = event.target;
   let className = field.classList[0];
-  var fieldType = (className === 'field') ? field.id : className;
+  var fieldType = (['field','dropdown'].includes(className)) ? field.id : className;
 
   // save field value
   saveValue(field.id);
@@ -72,6 +72,10 @@ function fieldChange(event) {
         document.getElementById("files").hidden = true;
         document.getElementById("load").hidden = true;
       }
+      break;
+    case 'environment':
+      document.body.style.backgroundColor = field.value === 'PROD' ? '#350000' : '';
+      field.style.backgroundColor = field.value === 'PROD' ? '#800000' : '';
       break;
   }
 }

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -39,6 +39,7 @@ function main() {
 
   // actions on panel load
   updateHighlightSet();
+  updateCurrentValuesHighlight();
   // on panel creation: update field outlines and tooltips
   checkFields();
 }
@@ -63,6 +64,7 @@ function fieldChange(event) {
   switch (fieldType) {
     case 'previous':
       updateHighlightSet();
+      updateCurrentValuesHighlight();
       break;
     case 'showload':
       if (field.checked) {
@@ -101,6 +103,24 @@ function updateHighlightSet() {
   }
 }
 
+function updateCurrentValuesHighlight() {
+  const prevs = document.querySelectorAll(".previousvaluefield");
+  const news = document.querySelectorAll(".newvaluefield");
+  const curs = document.querySelectorAll(".currentvaluefield");
+  const isPrevious = document.getElementById("previous").checked;
+
+  const compares = isPrevious ? prevs : news;
+
+  for (let index=0; index<curs.length; index++) {
+    if (curs[index].value === compares[index].value){
+      unHighlight(curs[index].id);
+    } else {
+      unequalHighlight(curs[index].id);
+    }
+  }
+
+}
+
 function highlightSet(fieldId) {
   let field = document.getElementById(fieldId);
   field.style.outline = "1px solid cyan";
@@ -109,6 +129,11 @@ function highlightSet(fieldId) {
 function unHighlight(fieldId) {
   let field = document.getElementById(fieldId);
   field.style.outline = "none";
+}
+
+function unequalHighlight(fieldId) {
+  let field = document.getElementById(fieldId);
+  field.style.outline = "1px dashed orange";
 }
 
 function infoMessage(info) {

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import {  dropdownOptions, toBoolean, uniqueArray, uniqueSort, arrayFrom1, arrayFrom0, nth, checkedString, valueString, hiddenString, removeQuotes, disabledString, escapeHtml, isEmpty} from "../utilities/functions";
+import {  dropdownOptions, toBoolean, uniqueArray, uniqueSort, arrayFrom1, arrayFrom0, nth, checkedString, valueString, hiddenString, removeQuotes, disabledString, backgroundColorString, escapeHtml, isEmpty} from "../utilities/functions";
 
 // fixed fields indices
 const parameterIndex = 0;
@@ -138,7 +138,7 @@ export class ParameterHtmlObject {
           Environment:
         </div>
         <div class="floatleft">
-          <vscode-dropdown id="environment" class="dropdown" index="${environmentIndex}" ${valueString(this._fieldValues[environmentIndex])} position="below">
+          <vscode-dropdown id="environment" class="dropdown" index="${environmentIndex}" ${backgroundColorString(this._fieldValues[environmentIndex] === 'PROD' ? 'red' : '')} ${valueString(this._fieldValues[environmentIndex])} position="below">
               ${dropdownOptions(this._environmentOptions)}
           </vscode-dropdown>
         </div>
@@ -221,11 +221,11 @@ export class ParameterHtmlObject {
     return ['file1.csv','file2.csv','file3.csv'];
   }
 
-  private _getBackgroundColor(input:string) : string {
+  private _getBackgroundColorString(input:string) : string {
     // if input is 'OK': green
     // else if input is '': ''
     // else: red
-    return input === 'OK' ? 'background-color:darkgreen' : (isEmpty(input) ? '' : 'background-color:maroon');
+    return input === 'OK' ? backgroundColorString('darkgreen') : (isEmpty(input) ? '' : backgroundColorString('maroon'));
   }
 
   private _getOptionText(status:number, message:string) : string {
@@ -253,13 +253,13 @@ export class ParameterHtmlObject {
       // const badEmoji: string = '&#10060;';
       // let emoji:string = this._getResponseValues[index] === 'OK' ? okEmoji : (isEmpty(this._getResponseValues[index]) ? '-' : badEmoji);
       
-      let backgroundColor:string =  this._getBackgroundColor(this._getResponseValues[index]?.message ?? '');
+      let bColorString:string =  this._getBackgroundColorString(this._getResponseValues[index]?.message ?? '');
       let optionText = this._getOptionText(this._getResponseValues[index]?.status ?? 0, this._getResponseValues[index]?.message ?? '');
       
       getResponseValues += /*html*/`
         <section class="component-option-fixed">
           <div id="getresponse${index}" class="getresponsefield" index="${index}">
-            <vscode-option style="${backgroundColor}">${optionText}</vscode-option>
+            <vscode-option ${bColorString}>${optionText}</vscode-option>
           </div>
         </section>
       `;
@@ -341,12 +341,12 @@ export class ParameterHtmlObject {
       // const badEmoji: string = '&#10060;';
       // this._setResponseValues[row] = '401';
       // let emoji:string = this._setResponseValues[row] === 'OK' ? okEmoji : (isEmpty(this._setResponseValues[row]) ? '-' : badEmoji);
-      let backgroundColor:string =  this._getBackgroundColor(this._setResponseValues[row]?.message ?? '');
+      let bColorString:string =  this._getBackgroundColorString(this._setResponseValues[row]?.message ?? '');
       let optionText = this._getOptionText(this._setResponseValues[row]?.status ?? 0, this._setResponseValues[row]?.value ?? '');
       setResponseValues += /*html*/`
         <section class="component-option-fixed">
           <div id="setresponse${row}" class="setresponsefield" index="${row}">
-            <vscode-option style="${backgroundColor}" title="${this._setResponseValues[row]?.message ?? ''}">${optionText}</vscode-option>
+            <vscode-option ${bColorString} title="${this._setResponseValues[row]?.message ?? ''}">${optionText}</vscode-option>
           </div>
         </section>
       `;

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getUri, getWorkspaceFile, removeQuotes, toBoolean, isEmpty, cleanPath, parentPath, getFileContentFromGlob } from "../utilities/functions";
+import { getUri, getWorkspaceFile, removeQuotes, toBoolean, isEmpty, cleanPath, parentPath, getFileContentFromGlob, getDateTimeStamp } from "../utilities/functions";
 import { ParameterHtmlObject } from "./ParameterHtmlObject";
 import * as fs from "fs";
 import axios from 'axios';
@@ -241,18 +241,35 @@ export class ParameterPanel {
   }
 
   private async _setParametersButton(extensionUri: vscode.Uri) {
+
+    // get url
     const urls: UrlObject = this._urls.filter(el => el.type === 'setparameters')[0];
     let url: string = this._getUrl(urls);
+
+    // refresh current values
+    await this._getCurrentValues();
+
+    // update input values
     let setValues: string[] = this._previous ? this._previousValues : this._newValues; 
-    
-    // save new and current values to file
-    let fileName:string = this._codeCompanyValues[0]+'_'+(new Date()).toISOString().substring(0,19).replace(/[\-T:]/g,'') + '.csv';
+    this._previousValues = this._currentValues;
+    this._newValues = setValues;
+    this._previous = false;
+
+    // save values to file
+    let fileName:string = this._codeCompanyValues[0]+'_'+ this._fieldValues[environmentIndex] +'_' + getDateTimeStamp() + '.csv';
     await this._writeFile(this._fieldValues[saveIndex]+ '/'+ fileName);
+
+    // clear previous responses and update webview
+    this._currentValues= [];
+    this._setResponseValues = [];
+    this._getResponseValues = [];
+    await this._updateWebview(extensionUri);
 
     // set param values
     for (let index = 0; index < this._codeCompanyValues.length; index++) {
       this._setResponseValues[index] = await this._setParameter(url,this._managerAuth,this._parameterNameValues[index],this._codeCompanyValues[index],this._codeCustomerValues[index],setValues[index], this._changeReasonValues[index]);
     }  
+
   }
 
   private async _setParameter(baseurl:string, authorization:string, parameterName:string, codeCompany:string, codeCustomer:string,parameterValue:string, changeReason:string) : Promise<ResponseObject> {
@@ -424,13 +441,7 @@ export class ParameterPanel {
     }
   }
 
-  private async _writeFile(filePath:string) {
-    // retrieve current values
-    await this._getCurrentValues();
-
-    // check which will be the next values
-    let nextValues: string[] = this._previous ? this._previousValues : this._newValues;
-    
+  private _writeFile(filePath:string) {
     // construct file content
     let fileContent: string = 'CodeCompany;CodeCustomer;Name;PreviousValue;NewValue;ChangeReason\r\n';
     for (let index=0; index < this._codeCompanyValues.length; index++) {
@@ -438,8 +449,8 @@ export class ParameterPanel {
       fileContent +=  this._codeCompanyValues[index] + this._delimiter
                     + this._codeCustomerValues[index] + this._delimiter
                     + this._parameterNameValues[index] + this._delimiter
-                    + this._currentValues[index] + this._delimiter
-                    + nextValues[index] + this._delimiter
+                    + this._previousValues[index] + this._delimiter
+                    + this._newValues[index] + this._delimiter
                     + this._changeReasonValues[index];
 
       // add newline

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -257,7 +257,7 @@ export class ParameterPanel {
 
     // save values to file
     let fileName:string = this._codeCompanyValues[0]+'_'+ this._fieldValues[environmentIndex] +'_' + getDateTimeStamp() + '.csv';
-    await this._writeFile(this._fieldValues[saveIndex]+ '/'+ fileName);
+    this._writeFile(this._fieldValues[saveIndex]+ '/'+ fileName);
 
     // clear previous responses and update webview
     this._currentValues= [];

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -378,3 +378,7 @@ export async function getFileContentFromGlob(glob:string) : Promise<string> {
 	return fs.readFileSync(path, 'utf8');
 }
 
+export function getDateTimeStamp() : string {
+	return (new Date()).toISOString().substring(0,19).replace(/[\-T:]/g,'');
+}
+

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -365,7 +365,16 @@ export function valueString(string: string): string {
     return !isEmpty(string) ? `value="${string}"` : '' ;
 }
 
+export function backgroundColorString(color:string): string {
+	let bColorString:string = '';
+	if (!isEmpty(color)) {
+		bColorString = `style="background-color:${color}"`;
+	}
+	return bColorString;
+}
+
 export async function getFileContentFromGlob(glob:string) : Promise<string> {
 	let path = await getWorkspaceFile(glob);
 	return fs.readFileSync(path, 'utf8');
 }
+


### PR DESCRIPTION
## 1.6.1
- Get/set Parameters
  - When Environment dropdown set to 'PROD', color dropdown bright red and panel background dark red
  - On pressing 'Set Parameter' button
    - Add environment name to saved file
    - Update input layout and highlight, uncheck 'previous' checkbox, clear previous Get/Set responses and current values
- Add highlight to current value fields which are unequal to new values (or previous values, if 'previous' checkbox is set)