### PR TITLE
Parameters further improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.6.6
+- Get/set parameters
+  - Horizontal tabbing through input fields
+  - auto-fill company, customer and change reason fields when adding new lines
+  - Add new line on `Ctrl` + `Enter` in last-line new parameter value or change reason fields
+  - On adding new line(s), auto-place cursor and focus to appropriate field in next line
+  - On 'get' and 'set', check on remaining parameter name option dropdowns which have not been selected with `Ctrl` + `Enter` yet
+
 ## 1.6.5
 - Get/set parameters
   - Allow searching for existing parameters by pressing `Enter` on parameter name field, and confirming choice from dropdown by pressing `Ctrl` + `Enter`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -40,6 +40,12 @@ function main() {
     field.addEventListener("keydown",parameterOptionsShow);
   }
 
+  // new line on ctrl+enter in new value or change reason fields
+  const newLineFields = document.querySelectorAll(".newvaluefield,.changereasonfield");
+  for (const field of newLineFields) {
+    field.addEventListener("keydown",addNewLine);
+  }
+
   // parameter search options select
   const parameterOptionsFields = document.querySelectorAll(".parameteroptionsfield");
   for (const field of parameterOptionsFields) {
@@ -153,6 +159,20 @@ function parameterOptionsShow(event) {
       errorMessage("Company, customer and parameter name values may not be empty");
     }
     
+  }
+}
+
+function addNewLine(event) {
+  const field = event.target;
+  if (event.key === 'Enter' && event.ctrlKey) {
+    let nofLinesField = document.getElementById("noflines");
+    let nofLines = +nofLinesField.value;
+    let index = field.getAttribute("index");
+
+    if (+index === (nofLines-1)) {
+      nofLinesField.value = (nofLines + 1).toString();
+      nofLinesField.dispatchEvent(new Event('change'));
+    }
   }
 }
 

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -53,31 +53,7 @@ function main() {
 
       // if parameter search visible: focus and show options
       if (field.hidden === false) {
-
-        // update field style
-        field.style.height = "1.6rem";
-        field.style.lineHeight = "1.6rem";
-        field.style.fontSize = "0.75rem";
-        field.style.fontWeight = "normal";
-
-        // update text and background color based on theme
-        if (document.body.classList.contains('vscode-dark')) {
-          field.style.background = '#454545';
-          field.style.color = '#CCCCCC';
-        } else if (document.body.classList.contains('vscode-high-contrast')) {
-          field.style.background = '#000000';
-          field.style.color = '#FFFFFF';
-        }
-
-        // focus and show items
-        field.focus();
-        //field.dispatchEvent(new Event('click'));
-
-        // press 'Enter'; from https://stackoverflow.com/a/18937620/1716283
-        // const ke = new KeyboardEvent('keydown', {
-        //     bubbles: true, cancelable: true, keyCode: 13
-        // });
-        // field.dispatchEvent(ke);
+        parameterOptionsStyleAndFocus(field.id);        
       }
   }
 
@@ -144,6 +120,37 @@ function fieldChange(event) {
 
       break;
   }
+}
+
+function parameterOptionsStyleAndFocus(fieldId) {
+  const field = document.getElementById(fieldId);
+
+  // update field style
+  field.style.height = "1.6rem";
+  field.style.lineHeight = "1.6rem";
+  field.style.fontSize = "0.8rem";
+  field.style.fontWeight = "normal";
+  field.style.borderWidth = "0px";
+  field.style.fontFamily = document.body.style.fontFamily;
+
+  // update text and background color based on theme
+  if (document.body.classList.contains('vscode-dark')) {
+    field.style.background = '#353535';
+    field.style.color = '#CCCCCC';
+  } else if (document.body.classList.contains('vscode-high-contrast')) {
+    field.style.background = '#000000';
+    field.style.color = '#FFFFFF';
+  }
+
+  // focus and show items
+  field.focus();
+  field.dispatchEvent(new Event('click'));
+
+  // press 'Enter'; from https://stackoverflow.com/a/18937620/1716283
+  // const ke = new KeyboardEvent('keydown', {
+  //     bubbles: true, cancelable: true, keyCode: 13
+  // });
+  // field.dispatchEvent(ke);
 }
 
 function parameterOptionsShow(event) {
@@ -398,6 +405,8 @@ function updateFieldOutlineAndTooltip(fieldId) {
   // update and return output
   if (check === 'empty') {
     updateEmpty(field.id);
+  } else if (fieldType === 'parameteroptionsfield' && field.hidden === false) {
+    updateWrong(field.id,'Select parameter and press Ctrl + Enter');
   } else if (check !== '' && check !== null) {
     updateWrong(field.id, getContentHint(fieldType));
   } else if (['codecompanyfield','codecustomerfield','parameternamefield'].includes(fieldType) && checkIfDuplicate(+field.getAttribute('index'))) {
@@ -428,7 +437,7 @@ function getContentHint(fieldType) {
 function checkFields() {
   // check if any incorrect field contents and update fields outlining and tooltip in the process
   var check = true;
-  const fields = document.querySelectorAll("#save,.codecompanyfield,.codecustomerfield,.parameternamefield,.changereasonfield");
+  const fields = document.querySelectorAll("#save,.codecompanyfield,.codecustomerfield,.parameternamefield,.changereasonfield,.parameteroptionsfield");
   for (const field of fields) {
     check = updateFieldOutlineAndTooltip(field.id) ? check : false;
   }

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -91,6 +91,8 @@ function main() {
   processingSet();
   processingGet();
 
+  // set focus if line number present
+  focusNewLine();
 }
 
 function fieldChange(event) {
@@ -162,6 +164,25 @@ function parameterOptionsShow(event) {
   }
 }
 
+function focusNewLine() {
+  let focusLine = document.getElementById("focusline").value;
+
+  if(focusLine.length > 0){
+    const focusCompany = document.getElementById("codecompany"+focusLine);
+    const focusCustomer = document.getElementById("codecustomer" + focusLine);
+    const focusParameter = document.getElementById("parametername"+focusLine);
+    focusParameter.focus();
+
+    if (isEmpty(focusCompany.value)) {
+      focusCompany.focus();
+    } else if (isEmpty(focusCustomer.value)) {
+      focusCustomer.focus();
+    } else {
+      focusParameter.focus();
+    }
+  }
+}
+
 function addNewLine(event) {
   const field = event.target;
   if (event.key === 'Enter' && event.ctrlKey) {
@@ -200,9 +221,9 @@ function focusAndCursor(fieldId) {
   const field = document.getElementById(fieldId);
 
   // focus and place cursor at end of content
-  const eol = field.value.length;
+  const eol = field.value.length ?? 0;
   field.focus();
-  field.setSelectionRange(eol, eol);
+  // field.setSelectionRange(eol, eol);
 }
 
 function checkIfDuplicate(row) {

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -171,12 +171,18 @@ function parameterOptionsSelect(event) {
     parameterField.hidden = false;
     field.hidden = true;
 
-    // focus and add cursor
-    const eol = parameterField.value.length;
-    parameterField.focus();
-    parameterField.setSelectionRange(eol, eol);
-    
+    // set focus and place cursor
+    focusAndCursor(parameterField.id);    
   }
+}
+
+function focusAndCursor(fieldId) {
+  const field = document.getElementById(fieldId);
+
+  // focus and place cursor at end of content
+  const eol = field.value.length;
+  field.focus();
+  field.setSelectionRange(eol, eol);
 }
 
 function checkIfDuplicate(row) {

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -95,7 +95,7 @@ export class ParameterHtmlObject {
 
           <section class="component-example">
             <div class="floatleftlesspadding">
-              ${this._getButton('getparameters','Get Parameters','codicon-refresh','secondary')}
+              ${this._getButton('getparameters','Get Parameters','codicon-refresh','secondary','',9)}
             </div>
             <div class="floatleftnopadding">
               <vscode-progress-ring id="processingget" ${hiddenString(this._processingGet)}></vscode-progress-ring>
@@ -130,10 +130,11 @@ export class ParameterHtmlObject {
     return html;
   }
 
-  private _getButton(id:string, title:string, codicon:string = '',appearance:string = 'primary',hidden:string = ''): string {
+  private _getButton(id:string, title:string, codicon:string = '',appearance:string = 'primary',hidden:string = '',tabindex:number=-2): string {
     let codiconString: string = isEmpty(codicon) ? '' : `<span slot="start" class="codicon ${codicon}"></span>`;
+    let tabindexString:string = tabindex < -1 ? '' : `tabindex="${tabindex.toString()}"` ;
     let button: string = /*html*/ `
-      <vscode-button id="${id}" appearance="${appearance}" ${hidden}>
+      <vscode-button id="${id}" appearance="${appearance}" ${tabindexString} ${hidden}>
         ${title}
         ${codiconString}
       </vscode-button>
@@ -162,7 +163,7 @@ export class ParameterHtmlObject {
           Environment:
         </div>
         <div class="floatleft">
-          <vscode-dropdown id="environment" class="dropdown" index="${environmentIndex}" ${backgroundColorString(this._fieldValues[environmentIndex] === 'PROD' ? 'red' : '')} ${valueString(this._fieldValues[environmentIndex])} position="below">
+          <vscode-dropdown id="environment" class="dropdown" index="${environmentIndex}" tabindex="2" ${backgroundColorString(this._fieldValues[environmentIndex] === 'PROD' ? 'red' : '')} ${valueString(this._fieldValues[environmentIndex])} position="below">
               ${dropdownOptions(this._environmentOptions)}
           </vscode-dropdown>
         </div>
@@ -170,15 +171,15 @@ export class ParameterHtmlObject {
           nofLines:
         </div>
         <div class="floatleft">
-          <vscode-dropdown id="noflines" class="dropdown" index="${noflinesIndex}" ${valueString(this._fieldValues[noflinesIndex])} position="below">
+          <vscode-dropdown id="noflines" class="dropdown" index="${noflinesIndex}" tabindex="3" ${valueString(this._fieldValues[noflinesIndex])} position="below">
             ${dropdownOptions(arrayFrom1(100))}
           </vscode-dropdown>
         </div>
         <div class="floatleft">
-          <vscode-checkbox id="previous" class="previous" ${disabledString(this._previousValues.length > 0)} ${checkedString(this._previous)}>Revert to Previous</vscode-checkbox>
+          <vscode-checkbox id="previous" class="previous"tabindex="4"  ${disabledString(this._previousValues.length > 0)} ${checkedString(this._previous)}>Revert to Previous</vscode-checkbox>
         </div>
         <div class="floatleftlesspadding">
-          ${this._getButton('setparameters','Set Parameters','codicon-arrow-right')}
+          ${this._getButton('setparameters','Set Parameters','codicon-arrow-right','primary','',5)}
         </div>
         <div class="floatleftnopadding">
           <vscode-progress-ring id="processingset" ${hiddenString(this._processingSet)}></vscode-progress-ring>
@@ -191,17 +192,17 @@ export class ParameterHtmlObject {
           Save file to folder:
         </div>
         <div class="floatleft">
-          <vscode-text-field id="save" class="field" index="${saveIndex}" ${valueString(this._fieldValues[saveIndex])}></vscode-text-field>
+          <vscode-text-field id="save" class="field" index="${saveIndex}" tabindex="6" ${valueString(this._fieldValues[saveIndex])}></vscode-text-field>
         </div>
         <div class="floatleft">
-          ${this._getButton('savetofile','Save input','codicon-arrow-right','secondary')}
+          ${this._getButton('savetofile','Save input','codicon-arrow-right','secondary','',7)}
         </div>
 
         <div class="floatleftmuchpadding">
           Set all change reasons:
         </div>
         <div class="floatleftnopadding">
-          <vscode-text-field id="allchangereasons" class="field" index="${allChangeReasonsIndex}" ${valueString(this._fieldValues[allChangeReasonsIndex])}></vscode-text-field>
+          <vscode-text-field id="allchangereasons" class="field" index="${allChangeReasonsIndex}" tabindex="8" ${valueString(this._fieldValues[allChangeReasonsIndex])}></vscode-text-field>
         </div>
       </section>
       `;
@@ -215,7 +216,7 @@ export class ParameterHtmlObject {
         ${dropdownOptions(this._getFileLoadOptions())}
       </vscode-dropdown>`;
 
-    let filesField: string = /*html*/ `<vscode-text-field id="files" class="field" index="${filesIndex}" ${valueString(this._fieldValues[filesIndex])}></vscode-text-field>`;
+    let filesField: string = /*html*/ `<vscode-text-field id="files" class="field" index="${filesIndex}" tabindex="0" ${valueString(this._fieldValues[filesIndex])}></vscode-text-field>`;
     
     let html: string = /*html*/ `
 
@@ -231,7 +232,7 @@ export class ParameterHtmlObject {
           ${filesField}
         </div>
         <div class="floatleft">
-          ${this._getButton('load','Load','codicon-arrow-up')}
+          ${this._getButton('load','Load','codicon-arrow-up',"primary",'',1)}
         </div>
       </section>
 
@@ -351,28 +352,28 @@ export class ParameterHtmlObject {
       // code company
       codeCompanys += /*html*/`
         <section class="component-minvmargin">
-          <vscode-text-field id="codecompany${row}" class="codecompanyfield" index="${row}" ${valueString(this._codeCompanyValues[row])} placeholder="CodeCompany"></vscode-text-field>
+          <vscode-text-field id="codecompany${row}" class="codecompanyfield" index="${row}" tabindex="${row +1}0" ${valueString(this._codeCompanyValues[row])} placeholder="CodeCompany"></vscode-text-field>
         </section>
       `;
 
       // code customer
       codeCustomers += /*html*/`
         <section class="component-minvmargin">
-          <vscode-text-field id="codecustomer${row}" class="codecustomerfield" index="${row}" ${valueString(this._codeCustomerValues[row])} placeholder="CodeCustomer"></vscode-text-field>
+          <vscode-text-field id="codecustomer${row}" class="codecustomerfield" index="${row}" tabindex="${row +1}1" ${valueString(this._codeCustomerValues[row])} placeholder="CodeCustomer"></vscode-text-field>
         </section>
       `;
 
       var showSearch: boolean = this._parameterSearchValues[row] !== undefined;
 
       var select: string = /*html*/ `
-        <select id="parameteroptions${row}" class="parameteroptionsfield" index="${row}" position="below" ${hiddenString(showSearch)}>
+        <select id="parameteroptions${row}" class="parameteroptionsfield" index="${row}" tabindex="${row +1}2" position="below" ${hiddenString(showSearch)}>
           ${selectOptions(this._parameterSearchValues[row] ?? [''])}
         </select>`;
 
       parameterNames += /*html*/`
         <section class="component-pname">
           <div class="floatpname">
-            <vscode-text-field id="parametername${row}" class="parameternamefield" index="${row}" ${valueString(this._parameterNameValues[row])} placeholder="parameter name" ${hiddenString(!showSearch)}></vscode-text-field>
+            <vscode-text-field id="parametername${row}" class="parameternamefield" index="${row}" tabindex="${row +1}3" ${valueString(this._parameterNameValues[row])} placeholder="parameter name" ${hiddenString(!showSearch)}></vscode-text-field>
             ${select}
           </div>
           
@@ -382,21 +383,21 @@ export class ParameterHtmlObject {
       // previous parameter value
       previousValues += /*html*/`
         <section class="component-minvmargin">
-          <vscode-text-field id="previousvalue${row}" class="previousvaluefield" index="${row}" ${valueString(escapeHtml(this._previousValues[row]??''))} readonly></vscode-text-field>
+          <vscode-text-field id="previousvalue${row}" class="previousvaluefield" index="${row}" tabindex="-1" ${valueString(escapeHtml(this._previousValues[row]??''))} readonly></vscode-text-field>
         </section>
       `;
 
       // new parameter value
       newValues += /*html*/`
         <section class="component-minvmargin">
-          <vscode-text-field id="newvalue${row}" class="newvaluefield" index="${row}" ${valueString(escapeHtml(this._newValues[row]??''))} placeholder="new parameter value"></vscode-text-field>
+          <vscode-text-field id="newvalue${row}" class="newvaluefield" index="${row}" tabindex="${row +1}5" ${valueString(escapeHtml(this._newValues[row]??''))} placeholder="new parameter value"></vscode-text-field>
         </section>
       `;
 
       // change reason
       changeReasonValues += /*html*/`
         <section class="component-minvmargin">
-          <vscode-text-field id="changereason${row}" class="changereasonfield" index="${row}" ${valueString(escapeHtml(this._changeReasonValues[row]??''))} placeholder="change reason"></vscode-text-field>
+          <vscode-text-field id="changereason${row}" class="changereasonfield" index="${row}" tabindex="${row +1}6" ${valueString(escapeHtml(this._changeReasonValues[row]??''))} placeholder="change reason"></vscode-text-field>
         </section>
       `;
 

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -48,7 +48,8 @@ export class ParameterHtmlObject {
     private _processingSet: boolean,
     private _processingGet: boolean,
     private _environmentOptions: string[],
-    private _codeCompanies: CodeCompanyObject[]
+    private _codeCompanies: CodeCompanyObject[],
+    private _focusLine: number
   ) { }
 
   // METHODS
@@ -84,6 +85,7 @@ export class ParameterHtmlObject {
 
         <section id="hidden">
             ${this._codeCompanyFields()}
+            <vscode-text-field id="focusline" value="${this._focusLine > 0 ? this._focusLine+'' : ''}"></vscode-text-field>
         </section>
 
         ${this._getLoadItems()}

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -85,7 +85,7 @@ export class ParameterHtmlObject {
 
         <section id="hidden">
             ${this._codeCompanyFields()}
-            <vscode-text-field id="focusline" value="${this._focusLine > 0 ? this._focusLine+'' : ''}"></vscode-text-field>
+            <vscode-text-field id="focusline" value="${this._focusLine > 0 ? this._focusLine+'' : ''}" hidden></vscode-text-field>
         </section>
 
         ${this._getLoadItems()}
@@ -97,7 +97,7 @@ export class ParameterHtmlObject {
 
           <section class="component-example">
             <div class="floatleftlesspadding">
-              ${this._getButton('getparameters','Get Parameters','codicon-refresh','secondary','',9)}
+              ${this._getButton('getparameters','Get Parameters','codicon-refresh','secondary')}
             </div>
             <div class="floatleftnopadding">
               <vscode-progress-ring id="processingget" ${hiddenString(this._processingGet)}></vscode-progress-ring>
@@ -130,11 +130,10 @@ export class ParameterHtmlObject {
     return html;
   }
 
-  private _getButton(id:string, title:string, codicon:string = '',appearance:string = 'primary',hidden:string = '',tabindex:number=-2): string {
+  private _getButton(id:string, title:string, codicon:string = '',appearance:string = 'primary',hidden:string = ''): string {
     let codiconString: string = isEmpty(codicon) ? '' : `<span slot="start" class="codicon ${codicon}"></span>`;
-    let tabindexString:string = tabindex < -1 ? '' : `tabindex="${tabindex.toString()}"` ;
     let button: string = /*html*/ `
-      <vscode-button id="${id}" appearance="${appearance}" ${tabindexString} ${hidden}>
+      <vscode-button id="${id}" appearance="${appearance}" ${hidden}>
         ${title}
         ${codiconString}
       </vscode-button>
@@ -163,7 +162,7 @@ export class ParameterHtmlObject {
           Environment:
         </div>
         <div class="floatleft">
-          <vscode-dropdown id="environment" class="dropdown" index="${environmentIndex}" tabindex="2" ${backgroundColorString(this._fieldValues[environmentIndex] === 'PROD' ? 'red' : '')} ${valueString(this._fieldValues[environmentIndex])} position="below">
+          <vscode-dropdown id="environment" class="dropdown" index="${environmentIndex}" ${backgroundColorString(this._fieldValues[environmentIndex] === 'PROD' ? 'red' : '')} ${valueString(this._fieldValues[environmentIndex])} position="below">
               ${dropdownOptions(this._environmentOptions)}
           </vscode-dropdown>
         </div>
@@ -171,15 +170,15 @@ export class ParameterHtmlObject {
           nofLines:
         </div>
         <div class="floatleft">
-          <vscode-dropdown id="noflines" class="dropdown" index="${noflinesIndex}" tabindex="3" ${valueString(this._fieldValues[noflinesIndex])} position="below">
+          <vscode-dropdown id="noflines" class="dropdown" index="${noflinesIndex}" ${valueString(this._fieldValues[noflinesIndex])} position="below">
             ${dropdownOptions(arrayFrom1(100))}
           </vscode-dropdown>
         </div>
         <div class="floatleft">
-          <vscode-checkbox id="previous" class="previous"tabindex="4"  ${disabledString(this._previousValues.length > 0)} ${checkedString(this._previous)}>Revert to Previous</vscode-checkbox>
+          <vscode-checkbox id="previous" class="previous" ${disabledString(this._previousValues.length > 0)} ${checkedString(this._previous)}>Revert to Previous</vscode-checkbox>
         </div>
         <div class="floatleftlesspadding">
-          ${this._getButton('setparameters','Set Parameters','codicon-arrow-right','primary','',5)}
+          ${this._getButton('setparameters','Set Parameters','codicon-arrow-right')}
         </div>
         <div class="floatleftnopadding">
           <vscode-progress-ring id="processingset" ${hiddenString(this._processingSet)}></vscode-progress-ring>
@@ -192,17 +191,17 @@ export class ParameterHtmlObject {
           Save file to folder:
         </div>
         <div class="floatleft">
-          <vscode-text-field id="save" class="field" index="${saveIndex}" tabindex="6" ${valueString(this._fieldValues[saveIndex])}></vscode-text-field>
+          <vscode-text-field id="save" class="field" index="${saveIndex}" ${valueString(this._fieldValues[saveIndex])}></vscode-text-field>
         </div>
         <div class="floatleft">
-          ${this._getButton('savetofile','Save input','codicon-arrow-right','secondary','',7)}
+          ${this._getButton('savetofile','Save input','codicon-arrow-right','secondary')}
         </div>
 
         <div class="floatleftmuchpadding">
           Set all change reasons:
         </div>
         <div class="floatleftnopadding">
-          <vscode-text-field id="allchangereasons" class="field" index="${allChangeReasonsIndex}" tabindex="8" ${valueString(this._fieldValues[allChangeReasonsIndex])}></vscode-text-field>
+          <vscode-text-field id="allchangereasons" class="field" index="${allChangeReasonsIndex}" ${valueString(this._fieldValues[allChangeReasonsIndex])}></vscode-text-field>
         </div>
       </section>
       `;
@@ -216,7 +215,7 @@ export class ParameterHtmlObject {
         ${dropdownOptions(this._getFileLoadOptions())}
       </vscode-dropdown>`;
 
-    let filesField: string = /*html*/ `<vscode-text-field id="files" class="field" index="${filesIndex}" tabindex="0" ${valueString(this._fieldValues[filesIndex])}></vscode-text-field>`;
+    let filesField: string = /*html*/ `<vscode-text-field id="files" class="field" index="${filesIndex}" ${valueString(this._fieldValues[filesIndex])}></vscode-text-field>`;
     
     let html: string = /*html*/ `
 
@@ -232,7 +231,7 @@ export class ParameterHtmlObject {
           ${filesField}
         </div>
         <div class="floatleft">
-          ${this._getButton('load','Load','codicon-arrow-up',"primary",'',1)}
+          ${this._getButton('load','Load','codicon-arrow-up')}
         </div>
       </section>
 

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -120,9 +120,7 @@ export class ParameterHtmlObject {
             </section> 
           </section>
 
-
         </section>
-
 			</body>
 		</html>
 	  `;


### PR DESCRIPTION
## 1.6.6
- Get/set parameters
  - Horizontal tabbing through input fields
  - auto-fill company, customer and change reason fields when adding new lines
  - Add new line on `Ctrl` + `Enter` in last-line new parameter value or change reason fields
  - On adding new line(s), auto-place cursor and focus to appropriate field in next line
  - On 'get' and 'set', check on remaining parameter name option dropdowns which have not been selected with `Ctrl` + `Enter` yet