### PR TITLE
Parameters options update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.6.8
+- Get/set parameters
+  - Removed explicit load options. From now on, load from right-mouse-click in explorer menu.
+  - When parameter option is selected, no longer necessary to switch back to field using `Ctrl` + `Enter`. Get/Set will work right away. To continue search, one still can press `Ctrl` + `Enter` and update the parameter manually.
+
 ## 1.6.7
 - Get/set parameters
   - Save input

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -11,7 +11,7 @@ function main() {
   document.getElementById("setparameters").addEventListener("click", setParameters);
   document.getElementById("savetofile").addEventListener("click", saveToFile);
   // document.getElementById("refresh").addEventListener("click", refreshContent);
-  document.getElementById("load").addEventListener("click",loadFile);
+  // document.getElementById("load").addEventListener("click",loadFile);
 
   // previous checkbox
   document.getElementById("previous").addEventListener("change", fieldChange);
@@ -51,18 +51,21 @@ function main() {
   for (const field of parameterOptionsFields) {
     field.addEventListener("keydown", parameterOptionsSelect);
 
-      // if parameter search visible: focus and show options
-      if (field.hidden === false) {
-        // focus and show items
-        field.focus();
-        // field.dispatchEvent(new Event('click'));
-        // field.dispatchEvent(new Event('mousedown')); 
-        
-        // press 'Enter'; from https://stackoverflow.com/a/18937620/1716283
-        // field.dispatchEvent(new Event('keydown', {
-        //     bubbles: true, cancelable: true, keyCode: 13
-        // }));
-      }
+    // if parameter search visible: focus and show options
+    if (field.hidden === false) {
+      // focus and show items
+      field.focus();
+
+      // setTimeout(() => {field.click();}, 100);
+      // field.click();
+      // field.dispatchEvent(new Event('click'));
+      // field.dispatchEvent(new Event('mousedown')); 
+      
+      // press 'Enter'; from https://stackoverflow.com/a/18937620/1716283
+      // field.dispatchEvent(new Event('keydown', {
+      //     bubbles: true, cancelable: true, keyCode: 13
+      // }));
+    }
   }
 
   // global keyboard shortcuts
@@ -361,11 +364,6 @@ function saveValue(fieldId) {
 
 function refreshContent() {
   vscodeApi.postMessage({ command: "refreshcontent", text: "" });
-}
-
-function loadFile() {
-  var path = document.getElementById("files").value;
-  vscodeApi.postMessage({ command: "loadfile", text: path });
 }
 
 function updateFieldOutlineAndTooltip(fieldId) {

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -10,8 +10,6 @@ function main() {
   document.getElementById("getparameters").addEventListener("click", getParameters);
   document.getElementById("setparameters").addEventListener("click", setParameters);
   document.getElementById("savetofile").addEventListener("click", saveToFile);
-  // document.getElementById("refresh").addEventListener("click", refreshContent);
-  // document.getElementById("load").addEventListener("click",loadFile);
 
   // previous checkbox
   document.getElementById("previous").addEventListener("change", fieldChange);
@@ -50,6 +48,7 @@ function main() {
   const parameterOptionsFields = document.querySelectorAll(".parameteroptionsfield");
   for (const field of parameterOptionsFields) {
     field.addEventListener("keydown", parameterOptionsSelect);
+    field.addEventListener("change",updateParameterFromOptions);
 
     // if parameter search visible: focus and show options
     if (field.hidden === false) {
@@ -196,16 +195,7 @@ function parameterOptionsShow(event) {
 }
 
 function parameterOptionsSelect(event) {
-  if (event.key === 'Enter' && event.ctrlKey) {
-    const field = event.target;
-    const value = field.value.replace(/\s\([\s\S]*/g,'');
-    const index = field.getAttribute('index');
-    const parameterField = document.getElementById('parametername' + index);
-    
-    // update parameter value
-    parameterField.value = value;
-    parameterField.dispatchEvent(new Event('keyup'));
-    
+  if (event.key === 'Enter' && event.ctrlKey) {   
     // hide/unhide
     parameterField.hidden = false;
     field.hidden = true;
@@ -213,6 +203,17 @@ function parameterOptionsSelect(event) {
     // set focus and place cursor
     focusAndCursor(parameterField.id);    
   }
+}
+
+function updateParameterFromOptions(event) {
+  const field = event.target;
+  const value = field.value.replace(/\s\([\s\S]*/g,'');
+  const index = field.getAttribute('index');
+  const parameterField = document.getElementById('parametername' + index);
+
+  // update parameter value
+  parameterField.value = value;
+  parameterField.dispatchEvent(new Event('keyup'));
 }
 
 function focusAndCursor(fieldId) {
@@ -391,8 +392,8 @@ function updateFieldOutlineAndTooltip(fieldId) {
   // update and return output
   if (check === 'empty') {
     updateEmpty(field.id);
-  } else if (fieldType === 'parameteroptionsfield' && field.hidden === false) {
-    updateWrong(field.id,'Select parameter and press Ctrl + Enter');
+  // } else if (fieldType === 'parameteroptionsfield' && field.hidden === false) {
+  //   updateWrong(field.id,'Select parameter and press Ctrl + Enter');
   } else if (check !== '' && check !== null) {
     updateWrong(field.id, getContentHint(fieldType));
   } else if (['codecompanyfield','codecustomerfield','parameternamefield'].includes(fieldType) && checkIfDuplicate(+field.getAttribute('index'))) {

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -87,8 +87,6 @@ export class ParameterHtmlObject {
             ${this._codeCompanyFields()}
             <vscode-text-field id="focusline" value="${this._focusLine > 0 ? this._focusLine+'' : ''}" hidden></vscode-text-field>
         </section>
-
-        ${this._getLoadItems()}
         
         <section class="rowflex">
           <section class="rowsingle">
@@ -207,40 +205,6 @@ export class ParameterHtmlObject {
       `;
 
     return getParametersGrid;
-  }
-
-  private _getLoadItems(): string {
-    let filesDropdown: string = /*html*/ `
-      <vscode-dropdown id="files" class="files" position="below">
-        ${dropdownOptions(this._getFileLoadOptions())}
-      </vscode-dropdown>`;
-
-    let filesField: string = /*html*/ `<vscode-text-field id="files" class="field" index="${filesIndex}" ${valueString(this._fieldValues[filesIndex])}></vscode-text-field>`;
-    
-    let html: string = /*html*/ `
-
-    <section class="rowsingle">
-      <vscode-divider role="separator"></vscode-divider>
-
-      <section class="component-example">
-        <p>Load from file<p>
-      </section>
-
-      <section class="component-example">
-        <div class="floatleft">
-          ${filesField}
-        </div>
-        <div class="floatleft">
-          ${this._getButton('load','Load','codicon-arrow-up')}
-        </div>
-      </section>
-
-      <vscode-divider role="separator"></vscode-divider>
-    </section>
-    
-    `;
-
-    return html;
   }
 
   private _getFileLoadOptions() : string[] {

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -200,19 +200,6 @@ export class ParameterPanel {
             
             break;
 
-          case 'loadfile':
-            this._loadFile(text);
-
-            // clear previous responses and update webview
-            this._currentValues= [];
-            this._currentChangeReasonValues = [];
-            this._currentTimestampValues = [];
-            this._extendedHistoryValues = [];
-            this._setResponseValues = [];
-            this._getResponseValues = [];
-            this._updateWebview(extensionUri);
-            break;
-
           case "savevalue":
             var classIndexValue = text.split('|');
             var clas = classIndexValue[0];
@@ -284,6 +271,14 @@ export class ParameterPanel {
       this._fieldValues[filesIndex] = loadFile;
       this._getPath();
       this._loadFile(loadFile);
+
+      // clear previous responses and update webview
+      this._currentValues= [];
+      this._currentChangeReasonValues = [];
+      this._currentTimestampValues = [];
+      this._extendedHistoryValues = [];
+      this._setResponseValues = [];
+      this._getResponseValues = [];
       this._updateWebview(extensionUri);
     }
   }


### PR DESCRIPTION
## 1.6.8
- Get/set parameters
  - Removed explicit load options. From now on, load from right-mouse-click in explorer menu.
  - When parameter option is selected, no longer necessary to switch back to field using `Ctrl` + `Enter`. Get/Set will work right away. To continue search, one still can press `Ctrl` + `Enter` and update the parameter manually.