### PR TITLE
Documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.6.12
+- Get/set parameters
+  - Now gets tool readme location glob from repo setting `stitch.parameters.readmeLocation` (and shows error if setting is not present)
+
 ## 1.6.11
 - Get/set parameters
   - Save file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.11",
+      "version": "1.6.12",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -70,7 +70,7 @@ export class ParameterPanel {
   private _codeCompanies: CodeCompanyObject[] = [];
   private _configGlob: string = "**/templater/parameters/";
   private _settingsGlob: string = "**/.vscode/settings.json";
-  private _readmeSetting: string = "stitch.parameters.readme";
+  private _readmeSetting: string = "stitch.parameters.readmeLocation";
   private _settings: any;
   private _focusField: string = '';
 
@@ -304,6 +304,10 @@ export class ParameterPanel {
   }
 
   private async _openInfoFile() {
+    if (isEmpty(this._settings[this._readmeSetting])) {
+      vscode.window.showErrorMessage("Missing repo setting " + this._readmeSetting);
+      return;
+    }
     const filePath:string = await getWorkspaceFile(this._settings[this._readmeSetting]);
     if (!isEmpty(filePath)) {
       const openPath = vscode.Uri.file(filePath);

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -68,9 +68,10 @@ export class ParameterPanel {
   private _urls: UrlObject[] = [];
   private _environmentOptions: string[] = [];
   private _codeCompanies: CodeCompanyObject[] = [];
-  private _settingsGlob: string = "**/templater/parameters/";
-  private _infoGlob: string = "**/docs/intro_get_set_parameters.md";
-  private _authLocation: string = 'parameters_auth/auth.json';
+  private _configGlob: string = "**/templater/parameters/";
+  private _settingsGlob: string = "**/.vscode/settings.json";
+  private _readmeSetting: string = "stitch.parameters.readme";
+  private _settings: any;
   private _focusField: string = '';
 
   // constructor
@@ -303,14 +304,12 @@ export class ParameterPanel {
   }
 
   private async _openInfoFile() {
-    const filePath:string = await getWorkspaceFile(this._infoGlob);
+    const filePath:string = await getWorkspaceFile(this._settings[this._readmeSetting]);
     if (!isEmpty(filePath)) {
       const openPath = vscode.Uri.file(filePath);
       // const doc = await vscode.workspace.openTextDocument(openPath);
       // vscode.window.showTextDocument(doc, vscode.ViewColumn.Two);
       await vscode.commands.executeCommand("markdown.showPreview", openPath);
-    } else {
-      vscode.window.showErrorMessage(`Missing info file '${this._infoGlob}'`);
     }
   }
 
@@ -615,7 +614,7 @@ export class ParameterPanel {
 
   private async _getCompanies() {
     // get companies and codecompanies from translation file
-    let translationPath = await getWorkspaceFile(this._settingsGlob + 'CompanyToCodeCompany.csv');
+    let translationPath = await getWorkspaceFile(this._configGlob + 'CompanyToCodeCompany.csv');
     let translations = fs.readFileSync(translationPath, 'utf8').replace(/\r/g,'').split("\n");
 
     this._codeCompanies = new Array<CodeCompanyObject>(translations.length);
@@ -753,10 +752,10 @@ export class ParameterPanel {
     this._urls = [];
 
     // retrieve urls
-    this._urls[0] = await this._getUrlObject(this._settingsGlob + 'parameter_get.json','getparameters');
-    this._urls[1] = await this._getUrlObject(this._settingsGlob + 'parameter_set.json','setparameters');
-    this._urls[2] = await this._getUrlObject(this._settingsGlob + 'parameter_get_history.json','getparameterhistory');
-    this._urls[3] = await this._getUrlObject(this._settingsGlob + 'parameter_get_parameter_codes.json','getparametercodes');
+    this._urls[0] = await this._getUrlObject(this._configGlob + 'parameter_get.json','getparameters');
+    this._urls[1] = await this._getUrlObject(this._configGlob + 'parameter_set.json','setparameters');
+    this._urls[2] = await this._getUrlObject(this._configGlob + 'parameter_get_history.json','getparameterhistory');
+    this._urls[3] = await this._getUrlObject(this._configGlob + 'parameter_get_parameter_codes.json','getparametercodes');
 
   }
 
@@ -768,12 +767,13 @@ export class ParameterPanel {
 
   private async _getEnvironmentOptions() {
     // get module dropdown options from txt file
-    let fileContent: string = await getFileContentFromGlob(this._settingsGlob + 'EnvironmentOptions.txt');
+    let fileContent: string = await getFileContentFromGlob(this._configGlob + 'EnvironmentOptions.txt');
     this._environmentOptions = fileContent.split("\n").map(el => el.trim());
   }
 
 
   private async _refresh() {
+    this._settings = JSON.parse(await getFileContentFromGlob(this._settingsGlob));
     await this._getAPIDetails();
     await this._getEnvironmentOptions();
     this._fieldValues[environmentIndex] = this._environmentOptions[0];

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -1,6 +1,7 @@
 import { Uri, Webview, workspace , ExtensionContext, window, Terminal} from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import * as vscode from "vscode";
 
 // type definitions
 type ScenarioObject = {
@@ -54,6 +55,8 @@ export async function getWorkspaceFile(matchString: string): Promise<string> {
 	let outPath = '';
 	if (functionsFiles.length > 0) {
 		outPath = cleanPath(functionsFiles[0].fsPath);
+	} else {
+		vscode.window.showErrorMessage('Could not locate file ' + matchString);
 	}
 	return outPath;
 }
@@ -415,8 +418,12 @@ export function backgroundColorString(color:string): string {
 }
 
 export async function getFileContentFromGlob(glob:string) : Promise<string> {
+	let content: string = '';
 	let path = await getWorkspaceFile(glob);
-	return fs.readFileSync(path, 'utf8');
+	if (!isEmpty(path)) {
+		content = fs.readFileSync(path, 'utf8');
+	}
+	return content;
 }
 
 export function getDateTimeStamp() : string {


### PR DESCRIPTION
## 1.6.12
- Get/set parameters
  - Now gets tool readme location glob from repo setting `stitch.parameters.readmeLocation` (and shows error if setting is not present)