### PR TITLE
Parameters more doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.6.13
+- Get/set parameters
+  - Style
+    - Link to documentation now shows as `info` badge (blue, next to panel header)
+    - Aligned get/set responses' colors with VSCode theme
+    - Fix: when selecting `PROD` environment, red hue of background and dropdown is now based on VSCode theme
+      - NOTE: if VSCode theme is changed, `get/set parameters` panel needs to be reopened for the `PROD` coloring to align
+  - Workspace setting `stitch.parameters.readmeLocation` can now contain either glob to local markdown file OR a url to an external web page
+
 ## 1.6.12
 - Get/set parameters
   - Now gets tool readme location glob from repo setting `stitch.parameters.readmeLocation` (and shows error if setting is not present)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.12",
+      "version": "1.6.13",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -291,31 +291,48 @@ function showProd() {
   const documentBgColor = getComputedStyle(field).getPropertyValue('--vscode-editor-background');
   const fieldBgColor = getComputedStyle(field).getPropertyValue('--vscode-dropdown-background');
   
-  document.body.style.backgroundColor = field.value === 'PROD' ? reddify(documentBgColor) : '';
-  field.style.backgroundColor = field.value === 'PROD' ? reddify(fieldBgColor,true) : '';
+  document.body.style.backgroundColor = field.value === 'PROD' ? colorify(documentBgColor,'red',50) : '';
+  field.style.backgroundColor = field.value === 'PROD' ? colorify(fieldBgColor,'red',100) : '';
 }
 
-function reddify(rgbhex,intenser=false) {
+function colorify(rgbhex, color, intensity) {
   // current color elements
   const red = parseInt(rgbhex.substring(1,3),16);
   const green = parseInt(rgbhex.substring(3,5),16);
   const blue = parseInt(rgbhex.substring(5,7),16);
 
-  // red step diff (amount red should go 'up', if possible)
-  const redStep = intenser ? 100 : 50;
+  const rgbArray = [red, green, blue];
+  let colorIndex = -1;
+  switch (color) {
+    case 'red':
+      colorIndex = 0;
+      break;
+    case 'green':
+      colorIndex = 1;
+      break;
+    case 'blue': 
+      colorIndex = 2;
+      break;
+    default:
+      colorIndex = 0;
+      break;
+  }
 
-  // green/blue step (amount green/blue need to go down)
-  const redOverStep = 255 - (red + redStep);
-  const gbStep = Math.min(redOverStep, 0);
+  // 'rest' step (amount non-colors need to go down)
+  const colorOverStep = 255 - (rgbArray[colorIndex] + intensity);
+  const restStep = Math.min(colorOverStep, 0);
 
   // new color elements
-  const newRed = Math.min(red + redStep,255).toString(16);
-  const newGreen = Math.max(green + gbStep,0).toString(16);
-  const newBlue = Math.max(blue + gbStep,0).toString(16);
+  let colorified = '#';
+  for (let index = 0; index < rgbArray.length; index++) {
+    if (index === colorIndex) {
+      colorified += Math.min(rgbArray[index] + intensity,255).toString(16);
+    } else {
+      colorified += Math.max(rgbArray[index] + restStep,0).toString(16);
+    }
+  }
 
-  const reddified = '#' + newRed + newGreen + newBlue;
-
-  return reddified;
+  return colorified;
 }
 
 function processingGet(push = false) {

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -288,9 +288,34 @@ function getCompanyName(codeCompany) {
 
 function showProd() {
   const field = document.getElementById("environment");
+  const documentBgColor = getComputedStyle(field).getPropertyValue('--vscode-editor-background');
+  const fieldBgColor = getComputedStyle(field).getPropertyValue('--vscode-dropdown-background');
+  
+  document.body.style.backgroundColor = field.value === 'PROD' ? reddify(documentBgColor) : '';
+  field.style.backgroundColor = field.value === 'PROD' ? reddify(fieldBgColor,true) : '';
+}
 
-  document.body.style.backgroundColor = field.value === 'PROD' ? '#350000' : '';
-  field.style.backgroundColor = field.value === 'PROD' ? '#800000' : '';
+function reddify(rgbhex,intenser=false) {
+  // current color elements
+  const red = parseInt(rgbhex.substring(1,3),16);
+  const green = parseInt(rgbhex.substring(3,5),16);
+  const blue = parseInt(rgbhex.substring(5,7),16);
+
+  // red step diff (amount red should go 'up', if possible)
+  const redStep = intenser ? 100 : 50;
+
+  // green/blue step (amount green/blue need to go down)
+  const redOverStep = 255 - (red + redStep);
+  const gbStep = Math.min(redOverStep, 0);
+
+  // new color elements
+  const newRed = Math.min(red + redStep,255).toString(16);
+  const newGreen = Math.max(green + gbStep,0).toString(16);
+  const newBlue = Math.max(blue + gbStep,0).toString(16);
+
+  const reddified = '#' + newRed + newGreen + newBlue;
+
+  return reddified;
 }
 
 function processingGet(push = false) {

--- a/scripts/parameter/style.css
+++ b/scripts/parameter/style.css
@@ -73,7 +73,12 @@ h1 {
 
 .setresponsefieldoption,
 .getresponsefieldoption {
-  color: #DDDDDD;
+  background-color: var(--vscode-inputValidation-errorBackground);
+}
+
+.setresponsefieldoption.ok,
+.getresponsefieldoption.ok {
+  background-color: var(--vscode-inputValidation-infoBackground);
 }
 
 #farright {

--- a/scripts/parameter/style.css
+++ b/scripts/parameter/style.css
@@ -5,7 +5,8 @@ h1 {
 }
 
 #info {
-  color: #9999FF;
+  background-color: darkblue;
+  color: #DDDDDD;
 }
 
 .component-pname {
@@ -70,8 +71,9 @@ h1 {
   width: 6rem;
 }
 
-.setresponsefield {
-  font-size: large;
+.setresponsefieldoption,
+.getresponsefieldoption {
+  color: #DDDDDD;
 }
 
 #farright {

--- a/scripts/parameter/style.css
+++ b/scripts/parameter/style.css
@@ -4,11 +4,6 @@ h1 {
   float:left;
 }
 
-#info {
-  background-color: darkblue;
-  color: #DDDDDD;
-}
-
 .component-pname {
   /* display:block; */
   /* white-space: nowrap; */
@@ -78,6 +73,10 @@ h1 {
 
 .setresponsefieldoption.ok,
 .getresponsefieldoption.ok {
+  background-color: var(--vscode-inputValidation-infoBackground);
+}
+
+#info {
   background-color: var(--vscode-inputValidation-infoBackground);
 }
 

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -78,7 +78,7 @@ export class ParameterHtmlObject {
 				<div class="row11" id="main">
           <section id="farleft">
 					  <h1>Get/set parameters</h1>   
-            <vscode-badge id="info" class="floatleft">i</vscode-badge>    
+            <vscode-option id="info" title="Click to view documentation">info</vscode-option>    
           </section>
           <section id="farright">
 
@@ -274,7 +274,7 @@ export class ParameterHtmlObject {
       getResponseValues += /*html*/`
         <section class="component-option-fixed">
           <div id="getresponse${index}" class="getresponsefield" index="${index}">
-            <vscode-option ${bColorString}>${optionText}</vscode-option>
+            <vscode-option class="getresponsefieldoption" ${bColorString}>${optionText}</vscode-option>
           </div>
         </section>
       `;
@@ -372,7 +372,7 @@ export class ParameterHtmlObject {
       setResponseValues += /*html*/`
         <section class="component-option-fixed">
           <div id="setresponse${row}" class="setresponsefield" index="${row}">
-            <vscode-option ${bColorString} title="${this._setResponseValues[row]?.message ?? ''}">${optionText}</vscode-option>
+            <vscode-option ${bColorString} class="setresponsefieldoption" title="${this._setResponseValues[row]?.message ?? ''}">${optionText}</vscode-option>
           </div>
         </section>
       `;

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -14,6 +14,7 @@ const allChangeReasonsIndex = 7;
 // type defs
 type ResponseObject = {
   status:number;
+  statusText:string;
   value:string;
   message:string;
 };
@@ -227,18 +228,29 @@ export class ParameterHtmlObject {
     return getParametersGrid;
   }
 
-  private _getBackgroundColorString(input:string) : string {
-    // if input is 'OK': green
-    // else if input is '': ''
-    // else: red
-    return input === 'OK' ? backgroundColorString('darkgreen') : (isEmpty(input) ? '' : backgroundColorString('maroon'));
-  }
-
-  private _getOptionText(status:number, message:string) : string {
+  private _getOptionText(response:ResponseObject) : string {
     // if message 'OK' : 'OK'
     // else if status 0: ''
     // else : '[status] : [message]'
-    return message === 'OK' ? message : ( status === 0 ? '' : (status.toString() + ' : ' + message));
+    return response?.statusText === 'OK' ? response?.statusText : ( response?.status === 0 ? '' : (response?.status.toString() + ' : ' + response?.statusText));
+  }
+
+  private _getResponseOption(idString:string, index:number, response:ResponseObject ): string {
+    let isOk:boolean = (response?.statusText ?? '') === 'OK';
+
+    let okClassString: string =  isOk ? ' ok' : '';
+    let optionText = this._getOptionText(response);
+    let titleString = isOk ? response?.statusText : `${response?.statusText ?? ''} : ${response?.message ?? ''}`;
+
+    let html: string = /*html*/`
+        <section class="component-option-fixed">
+          <div id="${idString}response${index}" class="${idString}responsefield" index="${index}" ${hiddenString(!isEmpty(response?.statusText ?? ''))}>
+            <vscode-option class="${idString}responsefieldoption${okClassString}" title="${titleString}">${optionText}</vscode-option>
+          </div>
+        </section>
+      `;
+
+    return html;
   }
 
   private _getCurrentValues(): string {
@@ -267,17 +279,8 @@ export class ParameterHtmlObject {
         </section>
       `;
 
-      // api response    
-      let bColorString:string =  this._getBackgroundColorString(this._getResponseValues[index]?.message ?? '');
-      let optionText = this._getOptionText(this._getResponseValues[index]?.status ?? 0, this._getResponseValues[index]?.message ?? '');
-      
-      getResponseValues += /*html*/`
-        <section class="component-option-fixed">
-          <div id="getresponse${index}" class="getresponsefield" index="${index}">
-            <vscode-option class="getresponsefieldoption" ${bColorString}>${optionText}</vscode-option>
-          </div>
-        </section>
-      `;
+      // api response      
+      getResponseValues += this._getResponseOption('get',index,this._getResponseValues[index]);
     }
 
     let html: string = /*html*/ `
@@ -367,16 +370,7 @@ export class ParameterHtmlObject {
       `;
 
       // api response
-      let bColorString:string =  this._getBackgroundColorString(this._setResponseValues[row]?.message ?? '');
-      let optionText = this._getOptionText(this._setResponseValues[row]?.status ?? 0, this._setResponseValues[row]?.value ?? '');
-      setResponseValues += /*html*/`
-        <section class="component-option-fixed">
-          <div id="setresponse${row}" class="setresponsefield" index="${row}">
-            <vscode-option ${bColorString} class="setresponsefieldoption" title="${this._setResponseValues[row]?.message ?? ''}">${optionText}</vscode-option>
-          </div>
-        </section>
-      `;
-
+      setResponseValues += this._getResponseOption('set',row, this._setResponseValues[row]);
     }
 
     let html: string = /*html*/ `

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -32,6 +32,7 @@ type UrlObject = {
 
 type ResponseObject = {
   status:number;
+  statusText:string;
   value:string;
   message:string;
 };
@@ -506,10 +507,6 @@ export class ParameterPanel {
     // const updatePer: number = 3;
     for (let index = 0; index < this._codeCompanyValues.length; index++) {
       this._setResponseValues[index] = await this._setParameter(url,this._getAuth(),this._parameterNameValues[index],this._codeCompanyValues[index],this._codeCustomerValues[index],setValues[index], this._changeReasonValues[index]);
-
-      // if ((index % updatePer) === 0 || index === (this._codeCompanyValues.length -1)) {
-      //   this._updateWebview(extensionUri);
-      // }
     }
 
     this._processingSet = false;
@@ -536,29 +533,37 @@ export class ParameterPanel {
       });
       result = {
         status: response.status,
-        value: response.statusText,
-        message: response.statusText
+        statusText: response.statusText,
+        value: '',
+        message: ''
       };
 
     } catch (err:any) {
-      let message: string;
-      if (err.response.data.hasOwnProperty('errors')) {
-        message = err.response.data?.errors[0]?.message;
-      } else if (err.response.data.hasOwnProperty('Message')) {
-        message = err.response.data.Message;
-      } else {
-        message = '';
-      }
-
       result = {
         status: err.response.status,
-        value: err.response.statusText,
-        message: err.response.statusText + ' : ' + message
+        statusText: err.response.statusText,
+        value: '',
+        message: this._getMessageFromError(err)
       };
     }
 
     return result;
   };
+
+  private _getMessageFromError(err:any) : string {
+    let message: string;
+    if (err?.response?.data.hasOwnProperty('errors')) {
+      message = err.response.data.errors[0]?.message;
+    } else if (err?.response?.data?.hasOwnProperty('Message')) {
+      message = err.response.data.Message;
+    } else if (err.hasOwnProperty('message')) {
+      message = err.message;
+    } else {
+      message = '';
+    }
+
+    return message;
+  }
 
   private async _getCurrentValues() {
     // get base urls
@@ -614,15 +619,18 @@ export class ParameterPanel {
 
       result = {
         status: response.status,
+        statusText: response.statusText,
         value: value,
-        message: response.statusText
+        message: ''
       };
 
     } catch (err:any) {
+
       result = {
         status: err.response.status,
+        statusText: err.response.statusText,
         value: '',
-        message: err.response.statusText
+        message: this._getMessageFromError(err)
       };
     }
 

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -320,9 +320,12 @@ export class ParameterPanel {
         await vscode.commands.executeCommand("markdown.showPreview", openPath);
       }
     } else {
-      // location is a URL
-      // vscode.env.openExternal(vscode.Uri.parse(readmeLocation));
-      await vscode.commands.executeCommand("simpleBrowser.show",readmeLocation);
+      // location is a URL: try tab in VSCode, else open in browser
+      try {
+        await vscode.commands.executeCommand("simpleBrowser.show",readmeLocation);
+      } catch (err) {
+        await vscode.env.openExternal(vscode.Uri.parse(readmeLocation));
+      }
     }
     
   }

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -304,17 +304,27 @@ export class ParameterPanel {
   }
 
   private async _openInfoFile() {
-    if (isEmpty(this._settings[this._readmeSetting])) {
+    let readmeLocation:string = this._settings[this._readmeSetting];
+
+    if (isEmpty(readmeLocation)) {
+      // settting missing
       vscode.window.showErrorMessage("Missing repo setting " + this._readmeSetting);
-      return;
+
+    } else if (readmeLocation.startsWith('**')) {
+      // location is a glob 
+      const filePath:string = await getWorkspaceFile(this._settings[this._readmeSetting]);
+      if (!isEmpty(filePath)) {
+        const openPath = vscode.Uri.file(filePath);
+        // const doc = await vscode.workspace.openTextDocument(openPath);
+        // vscode.window.showTextDocument(doc, vscode.ViewColumn.Two);
+        await vscode.commands.executeCommand("markdown.showPreview", openPath);
+      }
+    } else {
+      // location is a URL
+      // vscode.env.openExternal(vscode.Uri.parse(readmeLocation));
+      await vscode.commands.executeCommand("simpleBrowser.show",readmeLocation);
     }
-    const filePath:string = await getWorkspaceFile(this._settings[this._readmeSetting]);
-    if (!isEmpty(filePath)) {
-      const openPath = vscode.Uri.file(filePath);
-      // const doc = await vscode.workspace.openTextDocument(openPath);
-      // vscode.window.showTextDocument(doc, vscode.ViewColumn.Two);
-      await vscode.commands.executeCommand("markdown.showPreview", openPath);
-    }
+    
   }
 
   private _getAuth() : string {
@@ -798,7 +808,6 @@ export class ParameterPanel {
     if (this._urls.length === 0) {
       await this._refresh();
     }
-
 
     // reset focus field flag
     let focusField: string = this._focusField;


### PR DESCRIPTION
## 1.6.13
- Get/set parameters
  - Style
    - Link to documentation now shows as `info` badge (blue, next to panel header)
    - Aligned get/set responses' colors with VSCode theme
    - Fix: when selecting `PROD` environment, red hue of background and dropdown is now based on VSCode theme
      - NOTE: if VSCode theme is changed, `get/set parameters` panel needs to be reopened for the `PROD` coloring to align
  - Workspace setting `stitch.parameters.readmeLocation` can now contain either glob to local markdown file OR a url to an external web page