### PR TITLE
Parameters user feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 1.6.15
+- Get/set parameters
+  - Now clears get/set responses and previous values when:
+    - company, customer or parameter name is updated
+    - environment is changed
+    - new value is updated (only `set` response is cleared)
+  - Fix:
+    - Now allows input of new values that contain pipes '`|`'
+    - Parameter dropdowns
+      - Highlight red when company/customer/parameter line is duplicate
+      - Disable while using `get` or `set` button
+    - Check if current and new values match on updating new value field
+
 ## 1.6.14
 - Get/set parameters
   - Added option to navigate through the `Parameter inputs` grid using `Ctrl` + `up`/`down`/`left`/`right` arrow keys

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.14",
+      "version": "1.6.15",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "publisher": "ShipitSmarter",
 	"author": {
 		"name": "ShipitSmarter",

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -92,9 +92,9 @@ function fieldChange(event) {
   field.title = field.value;
 
   // update field outline and tooltip
-  if (['codecompanyfield','codecustomerfield','parameternamefield'].includes(fieldType)) {
+  if (['codecompanyfield','codecustomerfield','parameternamefield','parameteroptionsfield'].includes(fieldType)) {
     // codecompany, codecustomeror parametername: check all three in all rows
-    const rowFields = document.querySelectorAll(".codecompanyfield,.codecustomerfield,.parameternamefield");
+    const rowFields = document.querySelectorAll(".codecompanyfield,.codecustomerfield,.parameternamefield,.parameteroptionsfield");
     for (const rowField of rowFields) {
       updateFieldOutlineAndTooltip(rowField.id);
     }
@@ -515,7 +515,7 @@ function updateFieldOutlineAndTooltip(fieldId) {
     updateEmpty(field.id);
   } else if (check !== '' && check !== null) {
     updateWrong(field.id, getContentHint(fieldType));
-  } else if (['codecompanyfield','codecustomerfield','parameternamefield'].includes(fieldType) && checkIfDuplicate(+field.getAttribute('index'))) {
+  } else if (['codecompanyfield','codecustomerfield','parameternamefield','parameteroptionsfield'].includes(fieldType) && checkIfDuplicate(+field.getAttribute('index'))) {
     updateWrong(field.id, 'Company/customer/parameter combination is duplicate');
   } else {
     updateRight(field.id);

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -394,7 +394,7 @@ function processingGet(push = false) {
   const isProcessing = !document.getElementById("processingget").hidden;
 
   if (isProcessing) {
-    const disableFields = document.querySelectorAll("#environment,#noflines,#previous,#setparameters,#getparameters,#load,.codecompanyfield,.codecustomerfield,.parameternamefield");
+    const disableFields = document.querySelectorAll("#environment,#noflines,#previous,#setparameters,#getparameters,#load,.codecompanyfield,.codecustomerfield,.parameternamefield,.parameteroptionsfield");
     for (const dField of disableFields) {
       dField.disabled = true;
     }
@@ -408,7 +408,7 @@ function processingSet(push = false) {
   const isProcessing = !document.getElementById("processingset").hidden;
 
   if (isProcessing) {
-    const disableFields = document.querySelectorAll("#environment,#noflines,#previous,#allchangereasons,#setparameters,#getparameters,#load,.codecompanyfield,.codecustomerfield,.parameternamefield,.previousvaluefield,.newvaluefield,.changereasonfield");
+    const disableFields = document.querySelectorAll("#environment,#noflines,#previous,#allchangereasons,#setparameters,#getparameters,#load,.codecompanyfield,.codecustomerfield,.parameternamefield,.parameteroptionsfield,.previousvaluefield,.newvaluefield,.changereasonfield");
     for (const dField of disableFields) {
       dField.disabled = true;
     }

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -26,7 +26,7 @@ function main() {
   // save input fields
   const fields = document.querySelectorAll(".field,.codecompanyfield,.codecustomerfield,.parameternamefield,.newvaluefield,.changereasonfield");
   for (const field of fields) {
-    field.addEventListener("keyup", fieldChange);
+    field.addEventListener("input", fieldChange);
   }
 
   // update hover-overs on load
@@ -34,12 +34,6 @@ function main() {
   for (const field of allFields) {
     field.title = field.value;
   }
-
-  // show parameter search options
-  // const paramFields = document.querySelectorAll(".parameternamefield");
-  // for (const field of paramFields) {
-  //   field.addEventListener("keydown",parameterOptionsShow);
-  // }
 
   // keydown actions inside grid
   const lineFields = document.querySelectorAll(".codecompanyfield,.codecustomerfield,.parameternamefield,.parameteroptionsfield,.previousvaluefield,.newvaluefield,.changereasonfield");
@@ -112,13 +106,32 @@ function fieldChange(event) {
 
   // additional actions
   switch (fieldType) {
+    case 'codecompanyfield':
+    case 'codecustomerfield':
+    case 'parameternamefield':
+      clearGetResponse(field.id);
+      clearSetResponse(field.id);
+      clearPreviousValue(field.id);
+      break;
     case 'previous':
       updateHighlightSet();
     case 'newvaluefield':
       updateCurrentValuesHighlight();
+      clearSetResponse(field.id);
       break;
 
     case 'environment':
+      // clear responses, previous values
+      const nofLines = parseInt(document.getElementById('noflines').value);
+
+      for (let index = 0; index<nofLines; index++) {
+        var fieldId = "codecompany" + index.toString();
+        clearGetResponse(fieldId);
+        clearSetResponse(fieldId);
+        clearPreviousValue(fieldId);
+      }
+
+      // update panel coloring
       showProd();
       break;
 
@@ -136,6 +149,41 @@ function fieldChange(event) {
       document.getElementById("savename").innerHTML = nameFromPath(field.value);
       break;
   }
+}
+
+function clearValue(id, index) {
+  const text = id + '|' + index;
+  vscodeApi.postMessage({ command: "clearvalue", text: text });
+}
+
+function clearGetResponse(fieldId) {
+  const field = document.getElementById(fieldId);
+  const index = field.getAttribute("index");
+  const getResponse = document.getElementById("getresponsefieldoption" + index);
+
+  getResponse.innerHTML = "";
+  getResponse.title = "";
+  clearValue('getresponse',index);
+}
+
+function clearSetResponse(fieldId) {
+  const field = document.getElementById(fieldId);
+  const index = field.getAttribute("index");
+  const setResponse = document.getElementById("setresponsefieldoption" + index);
+
+  setResponse.innerHTML = "";
+  setResponse.title = "";
+  clearValue('setresponse',index);
+}
+
+function clearPreviousValue(fieldId) {
+  const field = document.getElementById(fieldId);
+  const index = field.getAttribute("index");
+  const previousField = document.getElementById("previousvalue" + index);
+
+  previousField.value = "";
+  previousField.title = "";
+  clearValue('previousvalue',index);
 }
 
 function gridKeydown(event) {
@@ -314,7 +362,7 @@ function updateParameterFromOptions(event) {
 
   // update parameter value
   parameterField.value = value;
-  parameterField.dispatchEvent(new Event('keyup'));
+  parameterField.dispatchEvent(new InputEvent('input'));
 }
 
 function checkIfDuplicate(row) {
@@ -352,6 +400,7 @@ function getCompanyName(codeCompany) {
 }
 
 function showProd() {
+  // update panel coloring
   const field = document.getElementById("environment");
   const documentBgColor = getComputedStyle(field).getPropertyValue('--vscode-editor-background');
   const fieldBgColor = getComputedStyle(field).getPropertyValue('--vscode-dropdown-background');

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -114,6 +114,7 @@ function fieldChange(event) {
   switch (fieldType) {
     case 'previous':
       updateHighlightSet();
+    case 'newvaluefield':
       updateCurrentValuesHighlight();
       break;
 

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -245,7 +245,7 @@ export class ParameterHtmlObject {
     let html: string = /*html*/`
         <section class="component-option-fixed">
           <div id="${idString}response${index}" class="${idString}responsefield" index="${index}" ${hiddenString(!isEmpty(response?.statusText ?? ''))}>
-            <vscode-option class="${idString}responsefieldoption${okClassString}" title="${titleString}">${optionText}</vscode-option>
+            <vscode-option id="${idString}responsefieldoption${index}" class="${idString}responsefieldoption${okClassString}" title="${titleString}">${optionText}</vscode-option>
           </div>
         </section>
       `;

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -229,9 +229,9 @@ export class ParameterHtmlObject {
   }
 
   private _getOptionText(response:ResponseObject) : string {
-    // if message 'OK' : 'OK'
+    // if statusText 'OK' : 'OK'
     // else if status 0: ''
-    // else : '[status] : [message]'
+    // else : '[status] : [statusText]'
     return response?.statusText === 'OK' ? response?.statusText : ( response?.status === 0 ? '' : (response?.status.toString() + ' : ' + response?.statusText));
   }
 

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -226,7 +226,9 @@ export class ParameterPanel {
             var classIndexValue = text.split('|');
             var clas = classIndexValue[0];
             var index = +classIndexValue[1];
-            var value = classIndexValue[2];
+            // value: everything after the second pipe '|'
+            var valueRegExp: RegExp = new RegExp(`^${classIndexValue[0]}\\\|${classIndexValue[1]}\\\|`);
+            var value = text.replace(valueRegExp,'');
             
             // do some updating and refreshing
             switch(clas) {

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -75,6 +75,13 @@ export class ParameterPanel {
   private _settings: any;
   private _focusField: string = '';
 
+  private _emptyResponse: ResponseObject = {
+    status: 0,
+    statusText: "",
+    value: "",
+    message: ""
+  }
+
   // constructor
   private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, context: vscode.ExtensionContext, loadFile:string = '') {
     this._panel = panel;
@@ -220,6 +227,24 @@ export class ParameterPanel {
           case 'deleteline':
             this._deleteLine(+text);
             this._updateWebview(extensionUri);
+            break;
+
+          case 'clearvalue':
+            var classIndex = text.split('|');
+            var clas = classIndex[0];
+            var index = +classIndex[1];
+
+            switch(clas) {
+              case 'getresponse':
+                this._getResponseValues[index] = this._emptyResponse;
+                break;
+              case 'setresponse':
+                this._setResponseValues[index] = this._emptyResponse;
+                break;
+              case 'previousvalue':
+                this._previousValues[index] = "";
+                break;
+            }
             break;
 
           case "savevalue":


### PR DESCRIPTION
## 1.6.15
- Get/set parameters
  - Now clears get/set responses and previous values when:
    - company, customer or parameter name is updated
    - environment is changed
    - new value is updated (only `set` response is cleared)
  - Fix:
    - Now allows input of new values that contain pipes '`|`'
    - Parameter dropdowns
      - Highlight red when company/customer/parameter line is duplicate
      - Disable while using `get` or `set` button
    - Check if current and new values match on updating new value field