### PR TITLE
Parameters create parameter code functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.6.21
+- Get/set parameters
+  - Create missing parameters functionality
+    - 'Check' button to check for missing parameters
+    - Grid with missing parameter codes, description and explanation fields, checkboxes to select/unselect which to create
+    - 'Create' button to create
+    - Missing parameter code check added to 'set parameters' button action; when there are missing parameters:
+      - Will show list of missing parameters and 'create' option
+      - Will highlight missing parameter code fields in input grid
+      - Will not execute 'set' action
+  - Added '+' button at bottom of input grid to add a line
+  - Fix:
+    - Fixed not-loading CodeCompany values from utf8-with-BOM encoded CSV
+    - Fixed get/set response outlining with rest of grid in case of 100+ lines
+
 ## 1.6.20
 - Get/set parameters
   - Fix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.6.20",
+  "version": "1.6.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.6.20",
+      "version": "1.6.21",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.6.20",
+  "version": "1.6.21",
   "publisher": "ShipitSmarter",
   "author": {
     "name": "ShipitSmarter",

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -15,10 +15,18 @@
   margin: 0.25rem 0;
 }
 
-.row1111 {
+.grid4flex {
   display: grid;
   grid-auto-rows: min-content;
   grid-template-columns: min-content min-content min-content min-content;
+  column-gap: 0.7rem;
+  row-gap: 0.3rem;
+}
+
+.grid7flex {
+  display: grid;
+  grid-auto-rows: min-content;
+  grid-template-columns: min-content min-content min-content min-content min-content min-content min-content;
   column-gap: 0.7rem;
   row-gap: 0.3rem;
 }

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -15,10 +15,10 @@
   margin: 0.25rem 0;
 }
 
-.row111 {
+.row1111 {
   display: grid;
   grid-auto-rows: min-content;
-  grid-template-columns: min-content min-content min-content;
+  grid-template-columns: min-content min-content min-content min-content;
   column-gap: 0.7rem;
   row-gap: 0.3rem;
 }

--- a/scripts/general/general.css
+++ b/scripts/general/general.css
@@ -15,10 +15,29 @@
   margin: 0.25rem 0;
 }
 
+.row111 {
+  display: grid;
+  grid-auto-rows: min-content;
+  grid-template-columns: min-content min-content min-content;
+  column-gap: 0.7rem;
+  row-gap: 0.3rem;
+}
+
+.flexwrapper {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .component-example {
   margin-bottom: 0.5rem;
   width: 100%;
   /* vertical-align: text-top; */
+}
+
+.component-topmargin {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  width: 100%;
 }
 
 .component-vmargin {

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -789,7 +789,26 @@ function checkParameterCodes() {
   vscodeApi.postMessage({ command: "checkparametercodes", text: "real fast!" });
 }
 function createParameterCodes() {
-  vscodeApi.postMessage({ command: "createparametercodes", text: "real fast!" });
+  // check if all fields are filled
+  var valid = true;
+  const newParamCheckboxes = document.querySelectorAll(".createnewparametercheckbox");
+  for (const newParamCheckbox of newParamCheckboxes) {
+    let index = newParamCheckbox.getAttribute("index");
+    let description = document.getElementById("newparameterdescription" + index);
+    let explanation = document.getElementById("newparameterexplanation" + index);
+
+    if (newParamCheckbox.checked && (isEmpty(description.value) || isEmpty(explanation.value))) {
+      valid = false;
+      break;
+    }
+  }
+
+  if (valid) {
+    vscodeApi.postMessage({ command: "createparametercodes", text: "real fast!" });
+  } else {
+    vscodeApi.postMessage({ command: "showerrormessage", text: "Description and explanation fields must be filled in to create parameter codes" });
+  }
+  
 }
 
 function getParameters() {

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -16,6 +16,13 @@ function main() {
     newparambutton.addEventListener("click", clickTile);
   }
 
+   // save new parameter description/explanation
+   const newparameterfields = document.querySelectorAll(".newparameterdescription,.newparameterexplanation");
+   for (const field of newparameterfields) {
+     field.addEventListener("input", fieldChange);
+   }
+ 
+
   // info onclick
   document.getElementById("info").addEventListener("click",infoClick);
 
@@ -35,7 +42,7 @@ function main() {
   }
 
   // update hover-overs on load
-  const allFields = document.querySelectorAll(".field,.parameternamefield,.previousvaluefield,.newvaluefield,.changereasonfield,.currentvaluefield,.currentchangereasonfield");
+  const allFields = document.querySelectorAll(".field,.parameternamefield,.previousvaluefield,.newvaluefield,.changereasonfield,.currentvaluefield,.currentchangereasonfield,.newparameterdescription,.newparameterexplanation");
   for (const field of allFields) {
     field.title = field.value;
   }

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -10,6 +10,7 @@ function main() {
   document.getElementById("getparameters").addEventListener("click", getParameters);
   document.getElementById("setparameters").addEventListener("click", setParameters);
   document.getElementById("savetofile").addEventListener("click", saveToFile);
+  document.getElementById("addline").addEventListener("click",addLine);
 
   // check new parameter codes button action
   document.getElementById("checknewparametercodes").addEventListener("click",checkParameterCodes);
@@ -372,9 +373,13 @@ function addLine(event) {
 
   let nofLinesField = document.getElementById("noflines");
   let nofLines = parseInt(nofLinesField.value);
-  let index = parseInt(field.getAttribute("index"));
+  let index = -1;
 
-  if (index === (nofLines-1)) {
+  if (['newvaluefield','changereasonfield'].includes(field.classList[0]) ) {
+    index = parseInt(field.getAttribute("index"));
+  }  
+
+  if (index === (nofLines-1) || field.id === 'addline') {
     nofLinesField.value = (nofLines + 1).toString();
     nofLinesField.dispatchEvent(new Event('change'));
   }

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -648,9 +648,10 @@ function unequalHighlight(fieldId) {
   field.style.outline = "1px dashed orange";
 }
 
-function missingHighlight(fieldId) {
+function updateMissing(fieldId) {
   let field = document.getElementById(fieldId);
   field.style.outline = "1px dashed orange";
+  field.title = 'Parameter code does not exist; must be created first'
 }
 
 function infoMessage(info) {
@@ -708,7 +709,7 @@ function updateFieldOutlineAndTooltip(fieldId) {
   } else if (['codecompanyfield','codecustomerfield','parameternamefield','parameteroptionsfield'].includes(fieldType) && checkIfDuplicate(+field.getAttribute('index'))) {
     updateWrong(field.id, 'Company/customer/parameter combination is duplicate');
   } else if (fieldType === 'parameternamefield' && getMissingParameterArray().includes(field.value)) {
-    missingHighlight(field.id);
+    updateMissing(field.id);
   } else {
     updateRight(field.id);
     isCorrect= true;

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -11,6 +11,11 @@ function main() {
   document.getElementById("setparameters").addEventListener("click", setParameters);
   document.getElementById("savetofile").addEventListener("click", saveToFile);
 
+  // new parameter code tile buttons
+  for (const newparambutton of document.querySelectorAll(".newparametercode")) {
+    newparambutton.addEventListener("click", clickTile);
+  }
+
   // info onclick
   document.getElementById("info").addEventListener("click",infoClick);
 
@@ -75,6 +80,20 @@ function main() {
     document.getElementById(focusId).focus();
   }
 }
+
+function clickTile(event) {
+  const field = event.target;
+
+  // update tile appearance and update selected param code array
+  if (field.getAttribute('appearance') === 'primary'){
+    field.setAttribute('appearance','secondary');
+    vscodeApi.postMessage({ command: "removeselectedparametercode", text: field.id });
+
+  } else {
+    field.setAttribute('appearance','primary');
+    vscodeApi.postMessage({ command: "addselectedparametercode", text: field.id });
+  }
+};
 
 function fieldChange(event) {
   const field = event.target;

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -11,6 +11,11 @@ function main() {
   document.getElementById("setparameters").addEventListener("click", setParameters);
   document.getElementById("savetofile").addEventListener("click", saveToFile);
 
+  // create parameter codes button action (if button exists)
+  for (const createParameterCodesButton of document.querySelectorAll("#createnewparametercodes")) {
+    createParameterCodesButton.addEventListener('click', createParameterCodes);
+  }
+
   // new parameter code tile buttons
   for (const newparambutton of document.querySelectorAll(".newparametercode")) {
     newparambutton.addEventListener("click", clickTile);
@@ -746,6 +751,10 @@ function parameterSearch(fieldId) {
 function codeCustomerSearch(fieldId) {
   const index = document.getElementById(fieldId).getAttribute('index');
   vscodeApi.postMessage({ command: "codecustomersearch", text: index });
+}
+
+function createParameterCodes() {
+  vscodeApi.postMessage({ command: "createparametercodes", text: "real fast!" });
 }
 
 function getParameters() {

--- a/scripts/parameter/main.js
+++ b/scripts/parameter/main.js
@@ -11,6 +11,9 @@ function main() {
   document.getElementById("setparameters").addEventListener("click", setParameters);
   document.getElementById("savetofile").addEventListener("click", saveToFile);
 
+  // check new parameter codes button action
+  document.getElementById("checknewparametercodes").addEventListener("click",checkParameterCodes);
+
   // create parameter codes button action (if button exists)
   for (const createParameterCodesButton of document.querySelectorAll("#createnewparametercodes")) {
     createParameterCodesButton.addEventListener('click', createParameterCodes);
@@ -753,6 +756,9 @@ function codeCustomerSearch(fieldId) {
   vscodeApi.postMessage({ command: "codecustomersearch", text: index });
 }
 
+function checkParameterCodes() {
+  vscodeApi.postMessage({ command: "checkparametercodes", text: "real fast!" });
+}
 function createParameterCodes() {
   vscodeApi.postMessage({ command: "createparametercodes", text: "real fast!" });
 }

--- a/scripts/parameter/style.css
+++ b/scripts/parameter/style.css
@@ -4,14 +4,6 @@ h1 {
   float:left;
 }
 
-.component-pname {
-  /* display:block; */
-  /* white-space: nowrap; */
-  /* width: 17rem; */
-  width: 100%;
-  margin-top: 0.5rem;
-}
-
 .newparameterdescription,
 .newparameterexplanation {
   width: 15rem;
@@ -110,13 +102,7 @@ h1 {
   padding-left: 4.5rem;
 }
 
-.floatpsearch {
-  float: left;
-  padding-left: 0.5rem;
-}
-
-.floatpname {
-  float: left;
-  margin-bottom: 0.5rem;
+.responsediv {
+  white-space: nowrap;
 }
 

--- a/scripts/parameter/style.css
+++ b/scripts/parameter/style.css
@@ -4,6 +4,7 @@ h1 {
   float:left;
 }
 
+.newparametercode,
 .newparameterdescription,
 .newparameterexplanation {
   width: 15rem;

--- a/scripts/parameter/style.css
+++ b/scripts/parameter/style.css
@@ -12,6 +12,11 @@ h1 {
   margin-top: 0.5rem;
 }
 
+.newparameterdescription,
+.newparameterexplanation {
+  width: 15rem;
+}
+
 .parameternamefield,
 .parameteroptionsfield,
 .previousvaluefield,

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -219,8 +219,8 @@ export class ParameterHtmlObject {
 
     let newParamSection:string = this._newParameterCodes.length === 0 ? '' : /*html*/ `
       <section class="flexwrapper">
-        <section class="row1111">
-          <div>-</div> 
+        <section class="grid4flex">
+          <div>-</div>
           <div>Param code</div>
           <div>Description</div>
           <div>Explanation</div>
@@ -306,7 +306,7 @@ export class ParameterHtmlObject {
     let titleString = isOk ? response?.statusText : `${response?.statusText ?? ''} : ${response?.message ?? ''}`;
 
     let html: string = /*html*/`
-        <section class="component-option-fixed">
+        <section class="component-nomargin">
           <div id="${idString}response${index}" class="${idString}responsefield" index="${index}" ${hiddenString(!isEmpty(response?.statusText ?? ''))}>
             <vscode-option id="${idString}responsefieldoption${index}" class="${idString}responsefieldoption${okClassString}" title="${titleString}">${optionText}</vscode-option>
           </div>
@@ -317,85 +317,64 @@ export class ParameterHtmlObject {
   }
 
   private _getCurrentValues(): string {
-    let currentValues: string = ``;
-    let currentChangeReasons: string = '';
-    let currentTimestamps: string = '';
-    let getResponseValues: string = '';
+    let currentValuesGrid: string = '';
 
     for (let index = 0; index < +this._fieldValues[noflinesIndex]; index++) {
 
-      currentValues += /*html*/`
-        <section class="component-minvmargin">
+      currentValuesGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="currentvalue${index}" class="currentvaluefield" value="${escapeHtml(this._currentValues[index] ?? '')}" readonly></vscode-text-field>
         </section>
       `;
 
-      currentChangeReasons += /*html*/`
-        <section class="component-minvmargin">
+      currentValuesGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="currentchangereason${index}" class="currentchangereasonfield" value="${this._currentChangeReasonValues[index] ?? ''}" readonly></vscode-text-field>
         </section>
       `;
 
-      currentTimestamps += /*html*/`
-        <section class="component-minvmargin">
+      currentValuesGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="currenttimestamp${index}" class="currenttimestampfield" value="${this._currentTimestampValues[index] ?? ''}" title="${this._extendedHistoryValues[index] ?? ''}" readonly></vscode-text-field>
         </section>
       `;
 
       // api response      
-      getResponseValues += this._getResponseOption('get',index,this._getResponseValues[index]);
+      currentValuesGrid += this._getResponseOption('get',index,this._getResponseValues[index]);
     }
 
     let html: string = /*html*/ `
-      <section class="component-example">
-        <section class="floatleftnopadding">
-          <p>Current value</p>
-          ${currentValues}
+      <section class="flexwrapper">
+        <section class="grid4flex">
+          <div>Current value</div>
+          <div>Change reason</div>
+          <div>Timestamp</div>
+          <div class="responsediv">Get Response</div>
+          ${currentValuesGrid}
         </section>
-
-        <section class="floatleftnopadding">
-          <p>Change reason</p>
-          ${currentChangeReasons}
-        </section>
-
-        <section class="floatleftnopadding">
-          <p>Timestamp</p>
-          ${currentTimestamps}
-        </section>
-
-        <section class="floatleft">
-          <p>Get Response</p>
-          ${getResponseValues}
-        </section>
-      </section>`;
+      </section>
+      `;
 
     return html;
   }
 
   private _parameterInputs(): string {
     let nofRows = +this._fieldValues[noflinesIndex];
-    let codeCompanys: string = '';
-    let codeCustomers: string = '';
-    let parameterNames: string = '';
-    let previousValues: string = '';
-    let newValues: string = '';
-    let changeReasonValues: string = '';
-    let setResponseValues: string = '';
+    let inputGrid: string = '';
     for (let row = 0; row < nofRows; row++) {
 
       // code company
-      codeCompanys += /*html*/`
-        <section class="component-minvmargin">
+      inputGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="codecompany${row}" class="codecompanyfield" index="${row}" tabindex="${row +1}0" ${valueString(this._codeCompanyValues[row])} placeholder="CodeCompany"></vscode-text-field>
         </section>
       `;
 
+      // code customer
       var showCodeCustomerSearch: boolean = (this._codeCustomerSearchValues[row] !== undefined) && (this._codeCustomerSearchValues[row].length > 0);
       let selectedCodeCustomerOption = showCodeCustomerSearch ? this._codeCustomerSearchValues[row].filter(el => el.includes(`(${this._codeCustomerValues[row]})`))[0] ?? this._codeCustomerValues[row] ?? '' : '';
-
-      // code customer
-      codeCustomers += /*html*/`
-        <section class="component-minvmargin">
+      inputGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="codecustomer${row}" class="codecustomerfield" index="${row}" tabindex="${row +1}1" ${valueString(this._codeCustomerValues[row])} placeholder="CodeCustomer" ${hiddenString(!showCodeCustomerSearch)}></vscode-text-field>
           <select id="codecustomeroptions${row}" class="codecustomeroptionsfield" index="${row}" tabindex="${row +1}2" position="below" title="${selectedCodeCustomerOption}" ${hiddenString(showCodeCustomerSearch)}>
             ${selectOptions(this._codeCustomerSearchValues[row] ?? [''],selectedCodeCustomerOption)}
@@ -403,76 +382,58 @@ export class ParameterHtmlObject {
         </section>
       `;
 
+      // parameter name
       var showSearch: boolean = (this._parameterSearchValues[row] !== undefined) && (this._parameterSearchValues[row].length > 0);
       let selectedOption = showSearch ? this._parameterSearchValues[row].filter(el => el.startsWith(this._parameterNameValues[row] + ' '))[0] ?? this._parameterNameValues[row] ?? '' : '';
 
-      parameterNames += /*html*/`
-        <section class="component-pname">
-          <div class="floatpname">
+      inputGrid += /*html*/`
+        <section class="component-nomargin">
             <vscode-text-field id="parametername${row}" class="parameternamefield" index="${row}" tabindex="${row +1}3" ${valueString(this._parameterNameValues[row])} placeholder="parameter name" ${hiddenString(!showSearch)}></vscode-text-field>
             <select id="parameteroptions${row}" class="parameteroptionsfield" index="${row}" tabindex="${row +1}4" position="below" title="${selectedOption}" ${hiddenString(showSearch)}>
               ${selectOptions(this._parameterSearchValues[row] ?? [''],selectedOption)}
             </select>
-          </div>
         </section>
       `;
 
       // previous parameter value
-      previousValues += /*html*/`
-        <section class="component-minvmargin">
+      inputGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="previousvalue${row}" class="previousvaluefield" index="${row}" tabindex="-1" ${valueString(escapeHtml(this._previousValues[row]??''))} readonly></vscode-text-field>
         </section>
       `;
 
       // new parameter value
-      newValues += /*html*/`
-        <section class="component-minvmargin">
+      inputGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="newvalue${row}" class="newvaluefield" index="${row}" tabindex="${row +1}5" ${valueString(escapeHtml(this._newValues[row]??''))} placeholder="new parameter value"></vscode-text-field>
         </section>
       `;
 
       // change reason
-      changeReasonValues += /*html*/`
-        <section class="component-minvmargin">
+      inputGrid += /*html*/`
+        <section class="component-nomargin">
           <vscode-text-field id="changereason${row}" class="changereasonfield" index="${row}" tabindex="${row +1}6" ${valueString(escapeHtml(this._changeReasonValues[row]??''))} placeholder="change reason"></vscode-text-field>
         </section>
       `;
 
       // api response
-      setResponseValues += this._getResponseOption('set',row, this._setResponseValues[row]);
+      inputGrid += this._getResponseOption('set',row, this._setResponseValues[row]);
     }
 
     let html: string = /*html*/ `
-      <section class="component-example">
-        <section class="floatleftnopadding">
-          <p>CodeCompany</p>
-          ${codeCompanys}
+      <section class="flexwrapper">
+        <section class="grid7flex">
+          <div>CodeCompany</div>
+          <div>CodeCustomer</div>
+          <div title="Enter to search, Ctrl + Enter to type">Parameter Name</div>
+          <div>Previous Value</div>
+          <div>New Value</div>
+          <div>Change Reason</div>
+          <div class="responsediv">Set Response</div>
+          ${inputGrid}
         </section>
-        <section class="floatleftnopadding">
-          <p>CodeCustomer</p>
-          ${codeCustomers}
-        </section>
-        <section class="floatleftnopadding">
-          <p title="Enter to search, Ctrl + Enter to type">Parameter Name</p>
-          ${parameterNames}
-        </section>
-        <section class="floatleftnopadding">
-          <p>Previous Value</p>
-          ${previousValues}
-        </section>
-        <section class="floatleftnopadding">
-          <p>New Value</p>
-          ${newValues}
-        </section>
-        <section class="floatleftnopadding">
-          <p>Change Reason</p>
-          ${changeReasonValues}
-        </section>
-        <section class="floatleft">
-          <p>Set Response</p>
-          ${setResponseValues}
-        </section>
-      </section>`;
+      </section>
+      `;
 
     return html;
   }

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -55,6 +55,8 @@ export class ParameterHtmlObject {
     private _codeCompanies: CodeCompanyObject[],
     private _focusField: string,
     private _newParameterCodes: string[],
+    private _newParameterDescriptionValues: string[],
+    private _newParameterExplanationValues: string[],
     private _selectedNewParameterCodes: string[]
   ) { }
 
@@ -195,20 +197,36 @@ export class ParameterHtmlObject {
   private _getCreateParameterCodes(): string {
 
     // list of parameter code buttons
-    let newParamButtons: string = '';
-    for (const newParamCode of this._newParameterCodes) {
-      newParamButtons += this._getButton(newParamCode, newParamCode,'',this._selectedNewParameterCodes.includes(newParamCode) ? 'primary' : 'secondary','','newparametercode');
+    let newParamGrid: string = '';
+    for (let index = 0; index < this._newParameterCodes.length; index++) {
+      let newParamCode:string = this._newParameterCodes[index];
+      newParamGrid += /*html*/ `
+        <section class="component-nomargin">
+          ${this._getButton(newParamCode, newParamCode,'',this._selectedNewParameterCodes.includes(newParamCode) ? 'primary' : 'secondary','','newparametercode')}
+        </section>
+        <section class="component-nomargin">
+          <vscode-text-field id="${newParamCode}_description" class="newparameterdescription" index="${index}" value="${escapeHtml(this._newParameterDescriptionValues[index] ?? '')}"></vscode-text-field>
+        </section>
+        <section class="component-nomargin">
+          <vscode-text-field id="${newParamCode}_explanation" class="newparameterexplanation" index="${index}" value="${escapeHtml(this._newParameterExplanationValues[index] ?? '')}"></vscode-text-field>
+        </section>
+        `;
     }
 
     let html: string = /*html*/ `
       <section class="rowsingle">
         <h3 title="Deselect parameter codes that should not be created">Create missing parameter codes</h3>
 
-        <section class="component-example">
-          ${newParamButtons}
+        <section class="flexwrapper">
+          <section class="row111">
+            <div>Param code</div>
+            <div>Description</div>
+            <div>Explanation</div>
+            ${newParamGrid}
+          </section>
         </section>
 
-        <section class="component-example">
+        <section class="component-topmargin">
             ${this._getButton('createnewparametercodes','Create','codicon-add','primary')}
         </section>
 

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -213,28 +213,34 @@ export class ParameterHtmlObject {
         `;
     }
 
+    let newParamSection:string = this._newParameterCodes.length === 0 ? '' : /*html*/ `
+      <section class="flexwrapper">
+        <section class="row111">
+          <div>Param code</div>
+          <div>Description</div>
+          <div>Explanation</div>
+          ${newParamGrid}
+        </section>
+      </section>
+
+      <section class="component-topmargin">
+          ${this._getButton('createnewparametercodes','Create','codicon-add','primary')}
+      </section>
+    `;
+
     let html: string = /*html*/ `
       <section class="rowsingle">
         <h3 title="Deselect parameter codes that should not be created">Create missing parameter codes</h3>
-
-        <section class="flexwrapper">
-          <section class="row111">
-            <div>Param code</div>
-            <div>Description</div>
-            <div>Explanation</div>
-            ${newParamGrid}
-          </section>
+        <section class="component-vmargin">
+            ${this._getButton('checknewparametercodes','Check','codicon-refresh','primary')}
         </section>
 
-        <section class="component-topmargin">
-            ${this._getButton('createnewparametercodes','Create','codicon-add','primary')}
-        </section>
-
+        ${newParamSection}
 
         <vscode-divider role="separator"></vscode-divider>
       <section class="rowsingle">`;
 
-      return this._newParameterCodes.length === 0 ? '' : html;
+      return html;
   }
 
   private _getDetailsGrid(): string {

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -95,6 +95,7 @@ export class ParameterHtmlObject {
         <section id="hidden">
             ${this._codeCompanyFields()}
             <vscode-text-field id="focusfield" ${valueString(this._focusField)} hidden></vscode-text-field>
+            <vscode-text-field id="missingparametercodes" ${valueString(this._newParameterCodes.join('|'))} hidden></vscode-text-field>
         </section>
 
         ${this._getSaveItems()}
@@ -202,20 +203,24 @@ export class ParameterHtmlObject {
       let newParamCode:string = this._newParameterCodes[index];
       newParamGrid += /*html*/ `
         <section class="component-nomargin">
-          ${this._getButton(newParamCode, newParamCode,'',this._selectedNewParameterCodes.includes(newParamCode) ? 'primary' : 'secondary','','newparametercode')}
+          <vscode-checkbox id="createnewparameter${index}" class="createnewparametercheckbox" index="${index}" ${checkedString(this._selectedNewParameterCodes.includes(newParamCode))}></vscode-checkbox>
         </section>
         <section class="component-nomargin">
-          <vscode-text-field id="${newParamCode}_description" class="newparameterdescription" index="${index}" value="${escapeHtml(this._newParameterDescriptionValues[index] ?? '')}"></vscode-text-field>
+          <vscode-text-field id="newparametercode${index}" class="newparametercode" index="${index}" value="${newParamCode}" readonly></vscode-text-field>
         </section>
         <section class="component-nomargin">
-          <vscode-text-field id="${newParamCode}_explanation" class="newparameterexplanation" index="${index}" value="${escapeHtml(this._newParameterExplanationValues[index] ?? '')}"></vscode-text-field>
+          <vscode-text-field id="newparameterdescription${index}" class="newparameterdescription" index="${index}" value="${escapeHtml(this._newParameterDescriptionValues[index] ?? '')}"></vscode-text-field>
+        </section>
+        <section class="component-nomargin">
+          <vscode-text-field id="newparameterexplanation${index}" class="newparameterexplanation" index="${index}" value="${escapeHtml(this._newParameterExplanationValues[index] ?? '')}"></vscode-text-field>
         </section>
         `;
     }
 
     let newParamSection:string = this._newParameterCodes.length === 0 ? '' : /*html*/ `
       <section class="flexwrapper">
-        <section class="row111">
+        <section class="row1111">
+          <div>-</div> 
           <div>Param code</div>
           <div>Description</div>
           <div>Explanation</div>

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -206,7 +206,7 @@ export class ParameterHtmlObject {
           <vscode-checkbox id="createnewparameter${index}" class="createnewparametercheckbox" index="${index}" ${checkedString(this._selectedNewParameterCodes.includes(newParamCode))}></vscode-checkbox>
         </section>
         <section class="component-nomargin">
-          <vscode-text-field id="newparametercode${index}" class="newparametercode" index="${index}" value="${newParamCode}" readonly></vscode-text-field>
+          <vscode-text-field id="newparametercode${index}" class="newparametercode" index="${index}" value="${newParamCode}" title="${newParamCode}" readonly></vscode-text-field>
         </section>
         <section class="component-nomargin">
           <vscode-text-field id="newparameterdescription${index}" class="newparameterdescription" index="${index}" value="${escapeHtml(this._newParameterDescriptionValues[index] ?? '')}"></vscode-text-field>

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -53,7 +53,9 @@ export class ParameterHtmlObject {
     private _processingGet: boolean,
     private _environmentOptions: string[],
     private _codeCompanies: CodeCompanyObject[],
-    private _focusField: string
+    private _focusField: string,
+    private _newParameterCodes: string[],
+    private _selectedNewParameterCodes: string[]
   ) { }
 
   // METHODS
@@ -94,6 +96,8 @@ export class ParameterHtmlObject {
         </section>
 
         ${this._getSaveItems()}
+
+        ${this._getCreateParameterCodes()}
         
         <section class="rowflex">
           <section class="rowsingle">
@@ -135,10 +139,11 @@ export class ParameterHtmlObject {
     return html;
   }
 
-  private _getButton(id:string, title:string, codicon:string = '',appearance:string = 'primary',hidden:string = ''): string {
+  private _getButton(id:string, title:string, codicon:string = '',appearance:string = 'primary',hidden:string = '',clas:string = ''): string {
     let codiconString: string = isEmpty(codicon) ? '' : `<span slot="start" class="codicon ${codicon}"></span>`;
+    let classString:string = isEmpty(clas) ? '' : `class="${clas}"`;
     let button: string = /*html*/ `
-      <vscode-button id="${id}" appearance="${appearance}" ${hidden}>
+      <vscode-button id="${id}" ${classString} appearance="${appearance}" ${hidden}>
         ${title}
         ${codiconString}
       </vscode-button>
@@ -185,6 +190,33 @@ export class ParameterHtmlObject {
       <section class="rowsingle">`;
 
       return html;
+  }
+
+  private _getCreateParameterCodes(): string {
+
+    // list of parameter code buttons
+    let newParamButtons: string = '';
+    for (const newParamCode of this._newParameterCodes) {
+      newParamButtons += this._getButton(newParamCode, newParamCode,'',this._selectedNewParameterCodes.includes(newParamCode) ? 'primary' : 'secondary','','newparametercode');
+    }
+
+    let html: string = /*html*/ `
+      <section class="rowsingle">
+        <h3 title="Deselect parameter codes that should not be created">Create missing parameter codes</h3>
+
+        <section class="component-example">
+          ${newParamButtons}
+        </section>
+
+        <section class="component-example">
+            ${this._getButton('createnewparametercodes','Create','codicon-add','primary')}
+        </section>
+
+
+        <vscode-divider role="separator"></vscode-divider>
+      <section class="rowsingle">`;
+
+      return this._newParameterCodes.length === 0 ? '' : html;
   }
 
   private _getDetailsGrid(): string {

--- a/src/panels/ParameterHtmlObject.ts
+++ b/src/panels/ParameterHtmlObject.ts
@@ -431,6 +431,9 @@ export class ParameterHtmlObject {
           <div>Change Reason</div>
           <div class="responsediv">Set Response</div>
           ${inputGrid}
+          <div>
+          ${this._getButton('addline','+','','primary')}
+          </div>
         </section>
       </section>
       `;

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -78,6 +78,8 @@ export class ParameterPanel {
   private _settings: any;
   private _focusField: string = '';
   private _newParameterCodes: string[] = [];
+  private _newParameterDescriptionValues: string[] = [];
+  private _newParameterExplanationValues: string[] = [];
   private _selectedNewParameterCodes: string[] = [];
 
   private _emptyResponse: ResponseObject = {
@@ -320,7 +322,12 @@ export class ParameterPanel {
 
                 }
                 break;
-
+              case 'newparameterdescription':
+                this._newParameterDescriptionValues[index] = value;
+                break;
+              case 'newparameterexplanation':
+                this._newParameterExplanationValues[index] = value;
+                break;
               case 'codecompanyfield':
                 this._codeCompanyValues[index] = value;
                 break;
@@ -541,6 +548,8 @@ export class ParameterPanel {
 
     // clear any previously found 'new' parameter codes
     this._newParameterCodes = [];
+    this._newParameterDescriptionValues = [];
+    this._newParameterExplanationValues = [];
     this._selectedNewParameterCodes = [];
 
     // refresh current values
@@ -888,6 +897,8 @@ export class ParameterPanel {
       this._codeCompanies,
       focusField,
       this._newParameterCodes,
+      this._newParameterDescriptionValues,
+      this._newParameterExplanationValues,
       this._selectedNewParameterCodes
     );
 

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -169,6 +169,9 @@ export class ParameterPanel {
             // });
             break;
 
+          case 'createparametercodes':
+            this._createParameterCodes();
+            break;
           case 'removeselectedparametercode':
             this._selectedNewParameterCodes = this._selectedNewParameterCodes.filter(el => el !== text);
             break;
@@ -541,6 +544,26 @@ export class ParameterPanel {
     }
   }
 
+  private async _createParameterCodes() {
+    // get url
+    const userPwd:string[] = getUserPwdFromAuth(getAuth());
+    const user = userPwd[0];
+    const pwd = userPwd[1];
+    const url:string = this._getUrl('code_param_create');
+    const fullUrl = `${url}?userid=${user}&password=${pwd}`;
+
+    // apply create
+    var responses:ResponseObject[] = [];
+    for (let index=0; index<this._newParameterCodes.length; index++) {
+      var pcode = this._newParameterCodes[index];
+      if (this._selectedNewParameterCodes.includes(pcode)) {
+        responses.push(await this._createParameterCode(fullUrl,pcode,this._newParameterDescriptionValues[index] ?? '',this._newParameterExplanationValues[index] ?? ''));
+      }
+    }
+
+    var henk = responses;
+  }
+
   private async _setParametersButton(extensionUri: vscode.Uri) {
 
     // get url
@@ -588,6 +611,40 @@ export class ParameterPanel {
     }
 
     this._processingSet = false;
+  }
+
+  private async _createParameterCode(url:string,codeParam:string, description:string,explanation:string="") : Promise<ResponseObject> {
+    let result: ResponseObject;
+    try {
+      const response = await axios({
+        method: "POST",
+        data: {
+          CodeParam: codeParam,
+          Description: description,
+          Explanation: explanation
+      },
+        url: url,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      result = {
+        status: response.status,
+        statusText: response.statusText,
+        value: '',
+        message: ''
+      };
+
+    } catch (err:any) {
+      result = {
+        status: err.response.status,
+        statusText: err.response.statusText,
+        value: '',
+        message: this._getMessageFromError(err)
+      };
+    }
+
+    return result;
   }
 
   private async _setParameter(baseurl:string, authorization:string, parameterName:string, codeCompany:string, codeCustomer:string,parameterValue:string, changeReason:string) : Promise<ResponseObject> {

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -171,7 +171,11 @@ export class ParameterPanel {
             break;
           
           case 'checkparametercodes':
-            this._checkParameterCodes().then( () => {
+            this._checkParameterCodes().then( (paramsExist) => {
+              // if no missing parameter codes: show info message
+              if (paramsExist) {
+                vscode.window.showInformationMessage('All listed parameters exist');
+              }
               this._updateWebview(extensionUri);
             });
             break;
@@ -589,11 +593,6 @@ export class ParameterPanel {
         this._newParameterCodes.push(pcode);
         this._selectedNewParameterCodes.push(pcode);
       }
-    }
-
-    // if no missing parameter codes: show info message
-    if (this._newParameterCodes.length === 0) {
-      vscode.window.showInformationMessage('All listed parameters exist');
     }
 
     return this._newParameterCodes.length === 0;

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -830,7 +830,8 @@ export class ParameterPanel {
   private _loadFile(filePath:string) {
 
     // load file
-    const fileContent = fs.readFileSync(filePath, {encoding:'utf8'});
+    // fix for BOM from: https://github.com/nodejs/node-v0.x-archive/issues/1918#issuecomment-2480359
+    const fileContent = fs.readFileSync(filePath, {encoding:'utf8'}).replace(/^\uFEFF/, '');
 
     // parse
     const content = csvParse.parse( fileContent, {

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getUri, getWorkspaceFile, removeQuotes, toBoolean, isEmpty, cleanPath, parentPath, getFileContentFromGlob, getDateTimeStamp, nameFromPath, isDirectory, getWorkspaceFiles, getAuth, checkAuth, saveAuth } from "../utilities/functions";
+import { getUri, getWorkspaceFile, removeQuotes, toBoolean, isEmpty, cleanPath, parentPath, getFileContentFromGlob, getDateTimeStamp, nameFromPath, isDirectory, getWorkspaceFiles, getAuth, checkAuth, saveAuth, getUserPwdFromAuth } from "../utilities/functions";
 import { ParameterHtmlObject } from "./ParameterHtmlObject";
 import * as fs from "fs";
 import axios from 'axios';

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -563,6 +563,40 @@ export class ParameterPanel {
 
     var henk = responses;
   }
+  
+  private async _createParameterCode(url:string,codeParam:string, description:string,explanation:string="") : Promise<ResponseObject> {
+    let result: ResponseObject;
+    try {
+      const response = await axios({
+        method: "POST",
+        data: {
+          CodeParam: codeParam,
+          Description: description,
+          Explanation: explanation
+      },
+        url: url,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      result = {
+        status: response.status,
+        statusText: response.statusText,
+        value: '',
+        message: ''
+      };
+
+    } catch (err:any) {
+      result = {
+        status: err.response.status,
+        statusText: err.response.statusText,
+        value: '',
+        message: this._getMessageFromError(err)
+      };
+    }
+
+    return result;
+  }
 
   private async _setParametersButton(extensionUri: vscode.Uri) {
 
@@ -611,40 +645,6 @@ export class ParameterPanel {
     }
 
     this._processingSet = false;
-  }
-
-  private async _createParameterCode(url:string,codeParam:string, description:string,explanation:string="") : Promise<ResponseObject> {
-    let result: ResponseObject;
-    try {
-      const response = await axios({
-        method: "POST",
-        data: {
-          CodeParam: codeParam,
-          Description: description,
-          Explanation: explanation
-      },
-        url: url,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
-      result = {
-        status: response.status,
-        statusText: response.statusText,
-        value: '',
-        message: ''
-      };
-
-    } catch (err:any) {
-      result = {
-        status: err.response.status,
-        statusText: err.response.statusText,
-        value: '',
-        message: this._getMessageFromError(err)
-      };
-    }
-
-    return result;
   }
 
   private async _setParameter(baseurl:string, authorization:string, parameterName:string, codeCompany:string, codeCustomer:string,parameterValue:string, changeReason:string) : Promise<ResponseObject> {

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -177,7 +177,11 @@ export class ParameterPanel {
             break;
 
           case 'createparametercodes':
-            this._createParameterCodes();
+            this._createParameterCodes().then(() => {
+              this._checkParameterCodes().then(() => {
+                this._updateWebview(extensionUri);
+              });
+            });
             break;
           case 'codecustomersearch':
             if (checkAuth()){
@@ -612,7 +616,7 @@ export class ParameterPanel {
       }
     }
 
-    var henk = responses;
+    vscode.window.showInformationMessage(`Created parameters: ${this._selectedNewParameterCodes.sort().join(', ')}`);
   }
   
   private async _createParameterCode(url:string,codeParam:string, description:string,explanation:string="") : Promise<ResponseObject> {

--- a/src/panels/ParameterPanel.ts
+++ b/src/panels/ParameterPanel.ts
@@ -168,6 +168,12 @@ export class ParameterPanel {
             //   this._updateWebview(extensionUri);
             // });
             break;
+          
+          case 'checkparametercodes':
+            this._checkParameterCodes().then( () => {
+              this._updateWebview(extensionUri);
+            });
+            break;
 
           case 'createparametercodes':
             this._createParameterCodes();
@@ -544,6 +550,33 @@ export class ParameterPanel {
     }
   }
 
+  private async _checkParameterCodes() {
+
+    // clear any previously found 'new' parameter codes
+    this._newParameterCodes = [];
+    this._newParameterDescriptionValues = [];
+    this._newParameterExplanationValues = [];
+    this._selectedNewParameterCodes = [];
+
+    // get url
+    const userPwd:string[] = getUserPwdFromAuth(getAuth());
+    const user = userPwd[0];
+    const pwd = userPwd[1];
+    const url:string = this._getUrl('code_param_get');
+    const fullUrl = `${url}?userid=${user}&password=${pwd}`;
+
+    for (let index = 0; index < this._parameterNameValues.length; index++) {
+      let pcode: string = this._parameterNameValues[index];
+
+      let response: ResponseObject = await this._getApiCall(`${fullUrl}&code_param=${pcode}`,'','');
+
+      if (!this._newParameterCodes.includes(pcode) && isEmpty(response.value)) {
+        this._newParameterCodes.push(pcode);
+        this._selectedNewParameterCodes.push(pcode);
+      }
+    }
+  }
+
   private async _createParameterCodes() {
     // get url
     const userPwd:string[] = getUserPwdFromAuth(getAuth());
@@ -603,12 +636,6 @@ export class ParameterPanel {
     // get url
     let url: string = this._getUrl('setparameters');
 
-    // clear any previously found 'new' parameter codes
-    this._newParameterCodes = [];
-    this._newParameterDescriptionValues = [];
-    this._newParameterExplanationValues = [];
-    this._selectedNewParameterCodes = [];
-
     // refresh current values
     await this._getCurrentValues();
 
@@ -636,11 +663,6 @@ export class ParameterPanel {
       // if param does not exist: add to new parameter codes array
       if (this._setResponseValues[index].status === 500) {
         let pcode:string = this._parameterNameValues[index];
-        
-        if (!this._newParameterCodes.includes(pcode)) {
-          this._newParameterCodes.push(pcode);
-          this._selectedNewParameterCodes.push(pcode);
-        }
       }
     }
 
@@ -884,7 +906,7 @@ export class ParameterPanel {
     this._urls[3] = await this._getUrlObject(this._configGlob + 'parameter_get_parameter_codes.json','getparametercodes');
     this._urls[4] = await this._getUrlObject(this._configGlob + 'parameter_get_codecustomers.json','getcodecustomers');
     this._urls[5] = await this._getUrlObject(this._configGlob + 'code_param_get.json','code_param_get');
-    this._urls[5] = await this._getUrlObject(this._configGlob + 'code_param_create.json','code_param_create');
+    this._urls[6] = await this._getUrlObject(this._configGlob + 'code_param_create.json','code_param_create');
 
   }
 

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -497,6 +497,21 @@ export async function saveAuth() {
     return authString;
   }
 
+  export function getUserPwdFromAuth(auth:string) : string[] {
+
+	// ignore everything before and including the space (if present)
+	const pureAuth:string = auth.replace(/[\s\S]*\s/g,'');
+
+	// decode
+	const buffer = Buffer.from(pureAuth,'base64');
+	const userPwd = buffer.toString();
+	
+	const user = userPwd.replace(/:[\s\S]*/g,''); 		// user is anything before the first colon
+	const pwd  = userPwd.replace(/^[^:]*:/g,''); 		// pwd is anything after the first colon
+
+	return [user, pwd];
+  }
+
   export function checkAuth() : boolean {
     let isValid: boolean = getAuth().length > 10;
     if (!isValid) {


### PR DESCRIPTION
## 1.6.21
- Get/set parameters
  - Create missing parameters functionality
    - 'Check' button to check for missing parameters
    - Grid with missing parameter codes, description and explanation fields, checkboxes to select/unselect which to create
    - 'Create' button to create
    - Missing parameter code check added to 'set parameters' button action; when there are missing parameters:
      - Will show list of missing parameters and 'create' option
      - Will highlight missing parameter code fields in input grid
      - Will not execute 'set' action
  - Added '+' button at bottom of input grid to add a line
  - Fix:
    - Fixed not-loading CodeCompany values from utf8-with-BOM encoded CSV
    - Fixed get/set response outlining with rest of grid in case of 100+ lines