### PR TITLE
Integration automation allow update of any existing integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.7.2
+- Carrier integration
+  - Now allows updating any integration (also ones which were not generated with the dashboard)
+  - Now allows loading existing integrations without an `api` subdirectory
+  - Performance: load integration details only when selected, not all at once at opening of dashboard or when hitting `refresh`
+- Postman collection
+  - Allow manual input of CarrierCode when not using the `independent` option
+
 ## 1.7.1
 - Carrier integration
   - Now allows adding steps to existing integrations (on `update`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "publisher": "ShipitSmarter",
   "author": {
     "name": "ShipitSmarter",

--- a/scripts/createintegration/main.js
+++ b/scripts/createintegration/main.js
@@ -210,6 +210,10 @@ function updateFieldOutlineAndTooltip(fieldId) {
   } else if (['carriername','carriercode'].includes(field.id) && isEmpty(field.value)) {
     updateFieldEmpty(field.id);
     isCorrect = false;
+  } else if (field.id === 'carrierapiname' && isEmpty(field.value) && isCreate()) {
+    // api field may not be empty if 'create'
+    updateFieldEmpty(field.id);
+    isCorrect = false;
   } else {
     updateFieldRight(field.id, fieldType);
   }

--- a/scripts/createintegration/main.js
+++ b/scripts/createintegration/main.js
@@ -207,7 +207,7 @@ function updateFieldOutlineAndTooltip(fieldId) {
   if (!checkContent(fieldType, field.value)) {
     updateFieldWrong(field.id,fieldType);
     isCorrect = false;
-  } else if (['carriername','carrierapiname','carriercode'].includes(field.id) && isEmpty(field.value)) {
+  } else if (['carriername','carriercode'].includes(field.id) && isEmpty(field.value)) {
     updateFieldEmpty(field.id);
     isCorrect = false;
   } else {

--- a/scripts/createintegration/main.js
+++ b/scripts/createintegration/main.js
@@ -102,6 +102,10 @@ function fieldChange(event) {
         checkbox.checked = field.checked;
       }  
       break;
+
+    case 'stepdropdown' :
+      field.title = field.value;
+      break;
   }
   
 }

--- a/scripts/createintegration/style.css
+++ b/scripts/createintegration/style.css
@@ -21,6 +21,10 @@
 }
 
 .stepdropdown,
+.stepfield {
+  width: 10rem;
+}
+
 #carriercode {
   width: 7rem;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,9 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showInformationMessage(`File ${fileName} has been sorted`);
 		}));
 
-		
 	});
 	context.subscriptions.push(sortScribanFunctionsFileCommand);
-	
 	
 }

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -239,13 +239,13 @@ export class CreateIntegrationHtmlObject {
       let enableStep: boolean = !this._existingSteps.includes(this._stepFieldValues[step]);
       // step name dropdown
       let stepNameDropdown = /*html*/`
-        <vscode-dropdown id="stepname${step}" index="${step}" ${valueString(this._stepFieldValues[step])} class="stepdropdown" position="below">
+        <vscode-dropdown id="stepname${step}" index="${step}" ${valueString(this._stepFieldValues[step])} class="stepdropdown" position="below" title="${this._stepFieldValues[step]}">
           ${dropdownOptions(this._stepOptions)}
         </vscode-dropdown>
       `;
 
       let stepNameField = /*html*/ `
-        <vscode-text-field id="stepname${step}" index="${step}" class="stepfield" ${valueString(this._stepFieldValues[step])} disabled></vscode-text-field>
+        <vscode-text-field id="stepname${step}" index="${step}" class="stepfield" ${valueString(this._stepFieldValues[step])} title="${this._stepFieldValues[step]}" disabled></vscode-text-field>
       `;
 
       stepGrid += /*html*/`

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -752,8 +752,11 @@ export class CreateIntegrationPanel {
     // first time only: get integrations, available scenarios, modular elements
     if (this._moduleOptions.length === 0) {
       await this._refresh();
-      this._stepTypes[0] = this._stepTypeOptions[0];
-      this._stepMethods[0] = this._stepMethodOptions[0];
+      if (isEmpty(this._stepTypes[0])) {
+        this._stepTypes[0] = this._stepTypeOptions[0];
+        this._stepMethods[0] = this._stepMethodOptions[0];
+      }
+      
       this._updatePackageTypes(0);
     }
 

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -362,7 +362,6 @@ export class CreateIntegrationPanel {
   }
 
   private async _getIntegrationObject() : Promise<IntegrationObject> {
-    //return this._integrationObjects.filter(el => this._fieldValues[carrierIndex] === el.carrier && this._fieldValues[apiIndex] === el.api  && this._fieldValues[moduleIndex] === el.module)[0] ?? this._emptyIntegrationObject;
     let elements:ElementsObject = {
       carrier: this._fieldValues[carrierIndex],
       api: this._fieldValues[apiIndex],
@@ -422,7 +421,6 @@ export class CreateIntegrationPanel {
 
     // clean existing scenario checkbox values upon clicking 'check' button
     this._existingScenarioCheckboxValues = [];
-
 
     // update panel
     this._updateWebview(extensionUri);
@@ -546,12 +544,10 @@ export class CreateIntegrationPanel {
           structure: newScenarios[index]
         };
       }
-      //let intIndex : number = this._integrationObjects.findIndex(el => el.path === this._currentIntegration.path);
-      //this._currentIntegration.path = newScriptPath;
+
       this._currentIntegration.scenarios = this._currentIntegration.scenarios.concat(newScenarios).sort();
       this._currentIntegration.validscenarios = this._currentIntegration.validscenarios.concat(scenarioObjects).sort();
       this._currentIntegration.steps = this._getStepsArray();
-      //this._integrationObjects[intIndex] = this._currentIntegration;
 
       // refresh window
       this._fieldValues[nofScenariosIndex] = "1";
@@ -652,16 +648,11 @@ export class CreateIntegrationPanel {
     // replace fixed field values
     for (let index = 0; index < this._fieldValues.length; index++) {
       let replaceString = '[fieldValues' + index + ']';
-      if (this._fieldValues[index] !== undefined) {
-        newScriptContent = newScriptContent.replace(replaceString, this._fieldValues[index] + "");
-      }
+      newScriptContent = newScriptContent.replace(replaceString, (this._fieldValues[index] ?? "") + "");
     }
 
     // createupdate
     newScriptContent = newScriptContent.replace('[createupdate]', this._createUpdateValue + "");
-
-    // modular
-    // newScriptContent = newScriptContent.replace('[modular]', this._modularValue + "");
 
     // scenarios
     newScriptContent = newScriptContent.replace(/\$Scenarios = \@\([^\)]+\)/g, this._getScenariosString());

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -505,7 +505,6 @@ export class CreateIntegrationPanel {
       // get template content
       let templateContent = fs.readFileSync(this._getTemplatePath(this._functionsPath), 'utf8');
 
-
       // replace all values in template
       let newScriptContent = this._replaceInScriptTemplate(templateContent);
 

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -504,35 +504,41 @@ export class CreateIntegrationPanel {
       // show info message
       vscode.window.showInformationMessage('Updating integration ' + this._getIntegrationName());
 
-      // load script content
-      let scriptContent = fs.readFileSync(this._currentIntegration.path, 'utf8');
-
-      // replace scenarios in script content
-      let newScriptContent: string = scriptContent.replace(/\$Scenarios = \@\([^\)]+\)/g, this._getScenariosString());
-
-      // replace steps
-      let stepsString: string = '\n"' + this._getStepsArray().join('",\n"') + '"\n';
-      newScriptContent = newScriptContent.replace(/(?<=\$Steps\s*=\s*@\()[^\)]*(?=\))/, stepsString);
-
-      // replace CreateOrUpdate value
-      newScriptContent = newScriptContent.replace(/\$CreateOrUpdate = '[^']+'/g, '$CreateOrUpdate = \'update\'');
-
-      // replace New-UpdateIntegration function call -> should be last line from template
+      // get template content
       let templateContent = fs.readFileSync(this._getTemplatePath(this._functionsPath), 'utf8');
-      let newNewUpdateIntegration = (templateContent.match(/\r?\n[^\r\n]*\s*$/) ?? [''])[0].trim();
-      newScriptContent = newScriptContent.replace(/New-UpdateIntegration\s[\S\s]+$/g,newNewUpdateIntegration);
 
-      // remove modular value if present
-      newScriptContent = newScriptContent.replace(/\$ModularXMLs[^\r\n]+[\r\n]/g, '');
+      // // load script content
+      // let scriptContent = fs.readFileSync(this._currentIntegration.path, 'utf8');
+
+      // // replace scenarios in script content
+      // let newScriptContent: string = scriptContent.replace(/\$Scenarios = \@\([^\)]+\)/g, this._getScenariosString());
+
+      // // replace steps
+      // let stepsString: string = '\n"' + this._getStepsArray().join('",\n"') + '"\n';
+      // newScriptContent = newScriptContent.replace(/(?<=\$Steps\s*=\s*@\()[^\)]*(?=\))/, stepsString);
+
+      // // replace CreateOrUpdate value
+      // newScriptContent = newScriptContent.replace(/\$CreateOrUpdate = '[^']+'/g, '$CreateOrUpdate = \'update\'');
+
+      // // replace New-UpdateIntegration function call -> should be last line from template
+      // let newNewUpdateIntegration = (templateContent.match(/\r?\n[^\r\n]*\s*$/) ?? [''])[0].trim();
+      // newScriptContent = newScriptContent.replace(/New-UpdateIntegration\s[\S\s]+$/g,newNewUpdateIntegration);
+
+      // // remove modular value if present
+      // newScriptContent = newScriptContent.replace(/\$ModularXMLs[^\r\n]+[\r\n]/g, '');
+
+      // replace all values in template
+      let newScriptContent = this._replaceInScriptTemplate(templateContent);
 
       // save to file
-      let newScriptPath:string = parentPath(cleanPath(this._currentIntegration.path)) + '/' + this._getScriptName();
+      //let newScriptDirectory: string = parentPath(cleanPath(this._currentIntegration.path)).replace(/(?<=\/carriers\/[^\/]+)[\s\S]*$/,'');
+      let newScriptPath:string = this._getCarrierPath(this._functionsPath) + '/' + this._getScriptName();
       fs.writeFileSync(newScriptPath, newScriptContent, 'utf8');
 
       // if new script path not equal to previous script path: delete old script file
-      if (newScriptPath !== this._currentIntegration.path) {
-        fs.rmSync(this._currentIntegration.path);
-      }
+      // if (newScriptPath !== this._currentIntegration.path) {
+      //   fs.rmSync(this._currentIntegration.path);
+      // }
 
       // execute powershell
       this._runScript(terminal, this._functionsPath);
@@ -549,7 +555,7 @@ export class CreateIntegrationPanel {
         };
       }
       let intIndex : number = this._integrationObjects.findIndex(el => el.path === this._currentIntegration.path);
-      this._currentIntegration.path = newScriptPath;
+      //this._currentIntegration.path = newScriptPath;
       this._currentIntegration.scenarios = this._currentIntegration.scenarios.concat(newScenarios).sort();
       this._currentIntegration.validscenarios = this._currentIntegration.validscenarios.concat(scenarioObjects).sort();
       this._currentIntegration.steps = this._getStepsArray();

--- a/src/panels/CreateIntegrationPanel.ts
+++ b/src/panels/CreateIntegrationPanel.ts
@@ -23,10 +23,9 @@ type IntegrationObject = {
   path:string, carrier:string, 
   api:string, module:string, 
   carriercode:string,
-   modular: boolean, 
-   scenarios:string[], 
-   validscenarios: ScenarioObject[],
-   steps: string[]
+  scenarios:string[], 
+  validscenarios: ScenarioObject[],
+  steps: string[]
 };
 
 type ModularElementObject = {
@@ -53,7 +52,7 @@ export class CreateIntegrationPanel {
   private _existingScenarioCheckboxValues: boolean[] = [];
   private _createUpdateValue: string = 'create';      // pre-allocate with 'create'
   private _integrationObjects:     IntegrationObject[] = [];
-  private _emptyIntegrationObject : IntegrationObject = {path: '', carrier: '', api: '', module: '', carriercode: '', modular: false, scenarios: [], validscenarios: [{name:'', structure:''}], steps: []};
+  private _emptyIntegrationObject : IntegrationObject = {path: '', carrier: '', api: '', module: '', carriercode: '', scenarios: [], validscenarios: [{name:'', structure:''}], steps: []};
   private _currentIntegration : IntegrationObject = this._emptyIntegrationObject;
   private _availableScenarios: string[] = [];
   private _modularElementsWithParents: ModularElementObject[] = [];
@@ -474,8 +473,7 @@ export class CreateIntegrationPanel {
         carrier: this._fieldValues[carrierIndex], 
         api: this._fieldValues[apiIndex], 
         module: this._fieldValues[moduleIndex], 
-        carriercode: this._fieldValues[carrierCodeIndex], 
-        modular: true, 
+        carriercode: this._fieldValues[carrierCodeIndex],
         scenarios: scenarioNames, 
         validscenarios: scenarioObjects,
         steps: steps

--- a/src/panels/CreatePostmanCollectionHtmlObject.ts
+++ b/src/panels/CreatePostmanCollectionHtmlObject.ts
@@ -240,7 +240,7 @@ export class CreatePostmanCollectionHtmlObject {
       <section class="component-example">
         <div class="floatleft">
           <p>Carrier Code</p>
-          <vscode-text-field id="carriercode" class="field" index="${carrierCodeIndex}" ${valueString(this._fieldValues[carrierCodeIndex])} readonly></vscode-text-field>
+          <vscode-text-field id="carriercode" class="field" index="${carrierCodeIndex}" ${valueString(this._fieldValues[carrierCodeIndex])} ${this._independent ? 'readonly' : ''}></vscode-text-field>
         </div>
         <div class="floatleft">
           <p>Account number</p>

--- a/src/panels/CreatePostmanCollectionPanel.ts
+++ b/src/panels/CreatePostmanCollectionPanel.ts
@@ -26,9 +26,9 @@ type IntegrationObject = {
   path:string, carrier:string, 
   api:string, module:string, 
   carriercode:string,
-   modular: boolean, 
-   scenarios:string[], 
-   validscenarios: ScenarioObject[]
+  scenarios:string[], 
+  validscenarios: ScenarioObject[],
+  steps: string[]
 };
 
 type ModularElementObject = {

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -221,7 +221,6 @@ export async function getIntegration(inputIntegrationJsonPath:string) : Promise<
 			carrier: 	 carrier,
 			api: 		 api,
 			module: 	 module,
-			// carriercode: getFromScript(scriptContent,'CARRIERCODE'),
 			carriercode: '',
 			scenarios:   scenarioNameStructures.map(el => el.name),
 			validscenarios: validScenarios,
@@ -235,8 +234,7 @@ export async function getIntegration(inputIntegrationJsonPath:string) : Promise<
 export async function getAvailableIntegrations(panel:string) : Promise<IntegrationObject[]> {
 	// panel input: 'integration' or 'postman'
 
-	// integration script path array
-	//let integrationScripts: string[] = await getWorkspaceFiles('**/carriers/*/create-*integration*.ps1');
+	// integration json path array
 	let integrationJsons: string[] = await getWorkspaceFiles('**/carriers/**/*.integration.json');
 
 	// pre-allocate output

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -15,7 +15,6 @@ type IntegrationObject = {
 	api:string, 
 	module:string, 
 	carriercode:string,
-	modular: boolean, 
 	scenarios:string[], 
 	validscenarios: ScenarioObject[],
 	steps: string[]
@@ -189,6 +188,7 @@ export async function getAvailableIntegrations(panel:string) : Promise<Integrati
 
 	// integration script path array
 	let integrationScripts: string[] = await getWorkspaceFiles('**/carriers/*/create-*integration*.ps1');
+	let integrationJsons: string[] = await getWorkspaceFiles('**/carriers/**/*.integration.json');
 
 	// pre-allocate output
 	let integrationObjects : IntegrationObject[] = new Array<IntegrationObject>(integrationScripts.length);
@@ -204,7 +204,7 @@ export async function getAvailableIntegrations(panel:string) : Promise<Integrati
 		let carrier: string   = getFromScript(scriptContent,'CarrierName');
 		let api: string       = getFromScript(scriptContent, 'CarrierAPI');
 		let module: string    = getFromScript(scriptContent,'Module');
-		let modular: boolean  = toBoolean(getFromScript(scriptContent, 'ModularXMLs').replace(/\$/,''));
+		// let modular: boolean  = toBoolean(getFromScript(scriptContent, 'ModularXMLs').replace(/\$/,''));
 		let apiSubPath = isEmpty(api) ? '' : (api + '/');
 
 		// if integration path does not exist: skip
@@ -216,7 +216,7 @@ export async function getAvailableIntegrations(panel:string) : Promise<Integrati
 
 		// check if any scenarios available, and if not, skip (because cannot make postman collection)
 		if (panel === 'postman') {
-			let scenarioGlob = modular ? `**/carriers/${carrier}/${apiSubPath}${module}/scenario-xmls/*.xml` : `**/scenario-templates/${module}/**/*.xml`;
+			let scenarioGlob = `**/scenario-templates/${module}/**/*.xml`;
 			let scenarios: string[] = await getWorkspaceFiles(scenarioGlob);
 			if (scenarios.length === 0) {
 				continue;
@@ -251,7 +251,6 @@ export async function getAvailableIntegrations(panel:string) : Promise<Integrati
 			api: 		 api,
 			module: 	 module,
 			carriercode: getFromScript(scriptContent,'CARRIERCODE'),
-			modular: 	 modular,
 			scenarios:   scenarioNameStructures.map(el => el.name),
 			validscenarios: validScenarios,
 			steps: 		 steps


### PR DESCRIPTION
## 1.7.2
- Carrier integration
  - Now allows updating any integration (also ones which were not generated with the dashboard)
  - Now allows loading existing integrations without an `api` subdirectory
  - Performance: load integration details only when selected, not all at once at opening of dashboard or when hitting `refresh`
- Postman collection
  - Allow manual input of CarrierCode when not using the `independent` option