### PR TITLE
Integration style updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.7.8
+- Carrier integration
+  - Renamed `Check` button to `Refresh`, and moved to top of the panel
+
 ## 1.7.7
 - Carrier integration
   - Add `info` button and functionality to link to documentation in local repo README or URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stitch-integration-templater",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stitch-integration-templater",
-      "version": "1.7.7",
+      "version": "1.7.8",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stitch-integration-templater",
   "displayName": "Stitch integration templater",
   "description": "Provides dashboard for creating and updating Stitch carrier integrations",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "publisher": "ShipitSmarter",
   "author": {
     "name": "ShipitSmarter",

--- a/scripts/createintegration/style.css
+++ b/scripts/createintegration/style.css
@@ -8,12 +8,18 @@
 }
 
 #farright {
-  margin-right: 10rem;
+  /* margin-right: 10rem; */
+  vertical-align: middle;
 }
 
 #createintegration {
   width:11rem;
   height:3rem;
+}
+
+#checkintegrationexists {
+  width:8rem;
+  height:2.5rem;
 }
 
 .existingscenariocustomfield {
@@ -40,4 +46,17 @@
 
 .stepup {
   background-color: #AAAA00;
+}
+
+.floatleftrefresh {
+  float:left;
+  /* vertical-align: middle; */
+  padding-top: 0.25rem;
+  padding-left: 10rem;
+  padding-right: 0rem;
+}
+
+.floatleftcreateupdate {
+  float: left;
+  padding-left: 5rem;
 }

--- a/src/panels/CreateIntegrationHtmlObject.ts
+++ b/src/panels/CreateIntegrationHtmlObject.ts
@@ -107,7 +107,14 @@ export class CreateIntegrationHtmlObject {
             <vscode-option id="info" title="Click to view documentation">info</vscode-option>
           </section>
           <section id="farright">
-            ${this._getCreateUpdateButton()}
+            <section class="component-example nowrap">
+              <div class="floatleftrefresh">
+              ${getButton("checkintegrationexists","Refresh","codicon-refresh")}
+              </div>
+              <div class="floatleftcreateupdate">
+              ${this._getCreateUpdateButton()}
+              </div>
+            </section>
           </section>
 				</div>
 
@@ -176,13 +183,6 @@ export class CreateIntegrationHtmlObject {
         <vscode-dropdown id="modulename" class="dropdown" index="${moduleIndex}" ${valueString(this._fieldValues[moduleIndex])} position="below">
           ${dropdownOptions(this._moduleOptions)}
         </vscode-dropdown>
-
-        <section class="component-nomargin">
-          <vscode-button id="checkintegrationexists" appearance="primary">
-            Check
-            <span slot="start" class="codicon codicon-refresh"></span>
-          </vscode-button>
-        </section>
       </section>
 
       ${this._ifCreate(this._getCarrierCodeField())}`;


### PR DESCRIPTION
## 1.7.8
- Carrier integration
  - Renamed `Check` button to `Refresh`, and moved to top of the panel